### PR TITLE
Merge ILSpy BAML Decompiler changes

### DIFF
--- a/Extensions/dnSpy.BamlDecompiler/Annotations.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Annotations.cs
@@ -1,7 +1,16 @@
+using dnSpy.BamlDecompiler.Xaml;
+
 namespace dnSpy.BamlDecompiler {
 	internal class BamlConnectionId {
 		public uint Id { get; }
 
 		public BamlConnectionId(uint id) => Id = id;
+	}
+
+	internal class TargetTypeAnnotation
+	{
+		public XamlType Type { get; }
+
+		public TargetTypeAnnotation(XamlType type) => Type = type;
 	}
 }

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Blocks/KeyElementStartHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Blocks/KeyElementStartHandler.cs
@@ -38,7 +38,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			var key = (XamlResourceKey)node.Annotation;
 
 			var bamlElem = new BamlElement(node);
-			bamlElem.Xaml = new XElement(ctx.GetXamlNsName("Key", parent.Xaml));
+			bamlElem.Xaml = new XElement(ctx.GetKnownNamespace("Key", XamlContext.KnownNamespace_Xaml, parent.Xaml));
 			parent.Xaml.Element.Add(bamlElem.Xaml.Element);
 			key.KeyElement = bamlElem;
 			base.Translate(ctx, node, bamlElem);

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/ConstructorParameterTypeHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/ConstructorParameterTypeHandler.cs
@@ -31,7 +31,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 		public BamlElement Translate(XamlContext ctx, BamlNode node, BamlElement parent) {
 			var record = (ConstructorParameterTypeRecord)((BamlRecordNode)node).Record;
 
-			var elem = new XElement(ctx.GetXamlNsName("TypeExtension", parent.Xaml));
+			var elem = new XElement(ctx.GetKnownNamespace("TypeExtension", XamlContext.KnownNamespace_Xaml, parent.Xaml));
 			elem.AddAnnotation(ctx.ResolveType(0xfd4d)); // Known type - TypeExtension
 
 			var bamlElem = new BamlElement(node);

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/DefAttributeHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/DefAttributeHandler.cs
@@ -31,7 +31,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			var record = (DefAttributeRecord)((BamlRecordNode)node).Record;
 
 			var attrName = ctx.ResolveString(record.NameId);
-			parent.Xaml.Element.Add(new XAttribute(ctx.GetXamlNsName(attrName), record.Value));
+			parent.Xaml.Element.Add(new XAttribute(ctx.GetKnownNamespace(attrName, XamlContext.KnownNamespace_Xaml), record.Value));
 
 			return null;
 		}

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/DefAttributeKeyStringHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/DefAttributeKeyStringHandler.cs
@@ -38,7 +38,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			var key = (XamlResourceKey)node.Annotation;
 
 			var bamlElem = new BamlElement(node);
-			bamlElem.Xaml = new XElement(ctx.GetXamlNsName("Key", parent.Xaml));
+			bamlElem.Xaml = new XElement(ctx.GetKnownNamespace("Key", XamlContext.KnownNamespace_Xaml, parent.Xaml));
 			parent.Xaml.Element.Add(bamlElem.Xaml.Element);
 			bamlElem.Xaml.Element.Value = ctx.ResolveString(record.ValueId);
 			key.KeyElement = bamlElem;

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/DefAttributeKeyTypeHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/DefAttributeKeyTypeHandler.cs
@@ -40,10 +40,10 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			var key = (XamlResourceKey)node.Annotation;
 
 			var bamlElem = new BamlElement(node);
-			bamlElem.Xaml = new XElement(ctx.GetXamlNsName("Key", parent.Xaml));
+			bamlElem.Xaml = new XElement(ctx.GetKnownNamespace("Key", XamlContext.KnownNamespace_Xaml, parent.Xaml));
 			parent.Xaml.Element.Add(bamlElem.Xaml.Element);
 
-			var typeElem = new XElement(ctx.GetXamlNsName("TypeExtension", parent.Xaml));
+			var typeElem = new XElement(ctx.GetKnownNamespace("TypeExtension", XamlContext.KnownNamespace_Xaml, parent.Xaml));
 			typeElem.AddAnnotation(ctx.ResolveType(0xfd4d)); // Known type - TypeExtension
 			typeElem.Add(new XElement(ctx.GetPseudoName("Ctor"), typeName));
 			bamlElem.Xaml.Element.Add(typeElem);

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/LiteralContentHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/LiteralContentHandler.cs
@@ -30,7 +30,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 		public BamlElement Translate(XamlContext ctx, BamlNode node, BamlElement parent) {
 			var record = (LiteralContentRecord)((BamlRecordNode)node).Record;
 
-			var elem = new XElement(ctx.GetXamlNsName("XData", parent.Xaml));
+			var elem = new XElement(ctx.GetKnownNamespace("XData", XamlContext.KnownNamespace_Xaml, parent.Xaml));
 			var content = XElement.Parse(record.Value);
 			elem.Add(content);
 

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/OptimizedStaticResourceHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/OptimizedStaticResourceHandler.cs
@@ -43,7 +43,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			if (record.IsType) {
 				var value = ctx.ResolveType(record.ValueId);
 
-				var typeElem = new XElement(ctx.GetXamlNsName("TypeExtension", parent.Xaml));
+				var typeElem = new XElement(ctx.GetKnownNamespace("TypeExtension", XamlContext.KnownNamespace_Xaml, parent.Xaml));
 				typeElem.AddAnnotation(ctx.ResolveType(0xfd4d)); // Known type - TypeExtension
 				typeElem.Add(new XElement(ctx.GetPseudoName("Ctor"), ctx.ToString(parent.Xaml, value)));
 				key = typeElem;
@@ -82,7 +82,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 					attrName = ctx.ToString(parent.Xaml, xName);
 				}
 
-				var staticElem = new XElement(ctx.GetXamlNsName("StaticExtension", parent.Xaml));
+				var staticElem = new XElement(ctx.GetKnownNamespace("StaticExtension", XamlContext.KnownNamespace_Xaml, parent.Xaml));
 				staticElem.AddAnnotation(ctx.ResolveType(0xfda6)); // Known type - StaticExtension
 				staticElem.Add(new XElement(ctx.GetPseudoName("Ctor"), attrName));
 				key = staticElem;

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/OptimizedStaticResourceHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/OptimizedStaticResourceHandler.cs
@@ -52,7 +52,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 				string attrName;
 				if (record.ValueId > 0x7fff) {
 					bool isKey = true;
-					short bamlId = (short)-record.ValueId;
+					short bamlId = unchecked((short)-record.ValueId);
 					if (bamlId > 232 && bamlId < 464) {
 						bamlId -= 232;
 						isKey = false;

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PresentationOptionsAttributeHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PresentationOptionsAttributeHandler.cs
@@ -31,7 +31,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			var record = (PresentationOptionsAttributeRecord)((BamlRecordNode)node).Record;
 
 			var attrName = ctx.ResolveString(record.NameId);
-			var attr = new XAttribute(ctx.GetXamlNsName(attrName, parent.Xaml), record.Value);
+			var attr = new XAttribute(ctx.GetKnownNamespace(attrName, XamlContext.KnownNamespace_PresentationOptions, parent.Xaml), record.Value);
 			parent.Xaml.Element.Add(attr);
 
 			return null;

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyCustomHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyCustomHandler.cs
@@ -47,7 +47,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 					case KnownTypes.DependencyPropertyConverter: {
 						if (value.Length == 2) {
 							var property = ctx.ResolveProperty(reader.ReadUInt16());
-							return ctx.ToString(elem, property.ToXName(ctx, elem, false));
+							return ctx.ToString(elem, property.ToXName(ctx, elem, NeedsFullName(property, elem)));
 						}
 						else {
 							var type = ctx.ResolveType(reader.ReadUInt16());
@@ -140,6 +140,15 @@ namespace dnSpy.BamlDecompiler.Handlers {
 				}
 			}
 			throw new NotSupportedException(ser.ToString());
+		}
+
+		static bool NeedsFullName(XamlProperty property, XElement elem) {
+			var p = elem.Parent;
+			while (p != null && p.Annotation<XamlType>()?.ResolvedType.FullName != "System.Windows.Style") {
+				p = p.Parent;
+			}
+			var type = p?.Annotation<TargetTypeAnnotation>()?.Type;
+			return type == null || property.IsAttachedTo(type);
 		}
 
 		public BamlElement Translate(XamlContext ctx, BamlNode node, BamlElement parent) {

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyTypeReferenceHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyTypeReferenceHandler.cs
@@ -42,7 +42,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			elem.Xaml.Element.AddAnnotation(elemAttr);
 			parent.Xaml.Element.Add(elem.Xaml.Element);
 
-			var typeElem = new XElement(ctx.GetXamlNsName("TypeExtension", parent.Xaml));
+			var typeElem = new XElement(ctx.GetKnownNamespace("TypeExtension", XamlContext.KnownNamespace_Xaml, parent.Xaml));
 			typeElem.AddAnnotation(ctx.ResolveType(0xfd4d)); // Known type - TypeExtension
 			typeElem.Add(new XElement(ctx.GetPseudoName("Ctor"), typeName));
 			elem.Xaml.Element.Add(typeElem);

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyTypeReferenceHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyTypeReferenceHandler.cs
@@ -39,6 +39,10 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			var elemAttr = ctx.ResolveProperty(record.AttributeId);
 			elem.Xaml = new XElement(elemAttr.ToXName(ctx, null));
 
+			if (attr.ResolvedMember?.FullName == "System.Windows.Style.TargetType") {
+				parent.Xaml.Element.AddAnnotation(new TargetTypeAnnotation(type));
+			}
+
 			elem.Xaml.Element.AddAnnotation(elemAttr);
 			parent.Xaml.Element.Add(elem.Xaml.Element);
 

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyWithExtensionHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyWithExtensionHandler.cs
@@ -36,7 +36,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 
 			var elemType = parent.Xaml.Element.Annotation<XamlType>();
 			var xamlProp = ctx.ResolveProperty(record.AttributeId);
-			var extType = ctx.ResolveType((ushort)-extTypeId);
+			var extType = ctx.ResolveType(unchecked((ushort)-extTypeId));
 			extType.ResolveNamespace(parent.Xaml, ctx);
 
 			var ext = new XamlExtension(extType);
@@ -56,7 +56,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 				string attrName;
 				if (record.ValueId > 0x7fff) {
 					bool isKey = true;
-					short bamlId = (short)-record.ValueId;
+					short bamlId = unchecked((short)-record.ValueId);
 					if (bamlId > 232 && bamlId < 464) {
 						bamlId -= 232;
 						isKey = false;

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/StaticResourceIdHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/StaticResourceIdHandler.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using dnSpy.BamlDecompiler.Baml;
+using dnSpy.BamlDecompiler.Xaml;
+
+namespace dnSpy.BamlDecompiler.Handlers {
+	class StaticResourceIdHandler : IHandler {
+		public BamlRecordType Type => BamlRecordType.StaticResourceId;
+
+		public BamlElement Translate(XamlContext ctx, BamlNode node, BamlElement parent) {
+			var record = (StaticResourceIdRecord)((BamlRecordNode)node).Record;
+
+			var found = node;
+			XamlResourceKey key;
+			do {
+				key = XamlResourceKey.FindKeyInAncestors(found.Parent, out found);
+			} while (key != null && record.StaticResourceId >= key.StaticResources.Count);
+
+			if (key == null)
+				throw new Exception("Cannot find StaticResource @" + node.Record.Position);
+
+			var resNode = key.StaticResources[record.StaticResourceId];
+
+			var handler = (IDeferHandler)HandlerMap.LookupHandler(resNode.Type);
+			var resElem = handler.TranslateDefer(ctx, resNode, parent);
+
+			parent.Children.Add(resElem);
+			resElem.Parent = parent;
+
+			return resElem;
+		}
+	}
+}

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/StaticResourceStartHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/StaticResourceStartHandler.cs
@@ -1,0 +1,28 @@
+﻿using System.Xml.Linq;
+using dnSpy.BamlDecompiler.Baml;
+using dnSpy.BamlDecompiler.Xaml;
+
+namespace dnSpy.BamlDecompiler.Handlers {
+	class StaticResourceStartHandler : IHandler, IDeferHandler {
+		public BamlRecordType Type => BamlRecordType.StaticResourceStart;
+
+		public BamlElement Translate(XamlContext ctx, BamlNode node, BamlElement parent) {
+			var record = (StaticResourceStartRecord)((BamlBlockNode)node).Record;
+			var key = XamlResourceKey.FindKeyInSiblings(node);
+
+			key.StaticResources.Add(node);
+			return null;
+		}
+
+		public BamlElement TranslateDefer(XamlContext ctx, BamlNode node, BamlElement parent) {
+			var record = (StaticResourceStartRecord)((BamlBlockNode)node).Record;
+			var doc = new BamlElement(node);
+			var elemType = ctx.ResolveType(record.TypeId);
+			doc.Xaml = new XElement(elemType.ToXName(ctx));
+			doc.Xaml.Element.AddAnnotation(elemType);
+			parent.Xaml.Element.Add(doc.Xaml.Element);
+			HandlerMap.ProcessChildren(ctx, (BamlBlockNode)node, doc);
+			return doc;
+		}
+	}
+}

--- a/Extensions/dnSpy.BamlDecompiler/Rewrite/AttributeRewritePass.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Rewrite/AttributeRewritePass.cs
@@ -20,6 +20,7 @@
 	THE SOFTWARE.
 */
 
+using System.Collections.Generic;
 using System.Xml.Linq;
 using dnSpy.BamlDecompiler.Xaml;
 
@@ -63,7 +64,13 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 			if (attrName != key)
 				attrName = property.ToXName(ctx, parent, property.IsAttachedTo(parent.Annotation<XamlType>()));
 			var attr = new XAttribute(attrName, value);
-			parent.Add(attr);
+			var list = new List<XAttribute>(parent.Attributes());
+			if (attrName == key)
+				list.Insert(0, attr);
+			else
+				list.Add(attr);
+			parent.RemoveAttributes();
+			parent.ReplaceAttributes(list);
 			elem.Remove();
 
 			return true;

--- a/Extensions/dnSpy.BamlDecompiler/Rewrite/AttributeRewritePass.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Rewrite/AttributeRewritePass.cs
@@ -29,7 +29,7 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 		XName key;
 
 		public void Run(XamlContext ctx, XDocument document) {
-			key = ctx.GetXamlNsName("Key");
+			key = ctx.GetKnownNamespace("Key", XamlContext.KnownNamespace_Xaml);
 
 			bool doWork;
 			do {

--- a/Extensions/dnSpy.BamlDecompiler/Rewrite/ConnectionIdRewritePass.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Rewrite/ConnectionIdRewritePass.cs
@@ -45,7 +45,7 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 		}
 
 		public void Run(XamlContext ctx, XDocument document) {
-			var xClass = document.Root.Elements().First().Attribute(ctx.GetXamlNsName("Class"));
+			var xClass = document.Root.Elements().First().Attribute(ctx.GetKnownNamespace("Class", XamlContext.KnownNamespace_Xaml));
 			if (xClass is null)
 				return;
 
@@ -113,7 +113,7 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 			public string FieldName;
 
 			public void Callback(XamlContext ctx, XElement elem) {
-				var xName = ctx.GetXamlNsName("Name");
+				var xName = ctx.GetKnownNamespace("Name", XamlContext.KnownNamespace_Xaml);
 				if (elem.Attribute("Name") is null && elem.Attribute(xName) is null)
 					elem.Add(new XAttribute(xName, FieldName));
 			}

--- a/Extensions/dnSpy.BamlDecompiler/Rewrite/MarkupExtensionRewritePass.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Rewrite/MarkupExtensionRewritePass.cs
@@ -78,14 +78,16 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 			var attrName = elem.Name;
 			if (attrName != key)
 				attrName = property.ToXName(ctx, parent, property.IsAttachedTo(type));
-			var attr = new XAttribute(attrName, extValue);
-			var list = new List<XAttribute>(parent.Attributes());
-			if (attrName == key)
-				list.Insert(0, attr);
-			else
-				list.Add(attr);
-			parent.RemoveAttributes();
-			parent.ReplaceAttributes(list);
+			if (!parent.Attributes(attrName).Any()) {
+				var attr = new XAttribute(attrName, extValue);
+				var list = new List<XAttribute>(parent.Attributes());
+				if (attrName == key)
+					list.Insert(0, attr);
+				else
+					list.Add(attr);
+				parent.RemoveAttributes();
+				parent.ReplaceAttributes(list);
+			}
 			elem.Remove();
 
 			return true;

--- a/Extensions/dnSpy.BamlDecompiler/Rewrite/MarkupExtensionRewritePass.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Rewrite/MarkupExtensionRewritePass.cs
@@ -32,7 +32,7 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 		XName ctor;
 
 		public void Run(XamlContext ctx, XDocument document) {
-			key = ctx.GetXamlNsName("Key");
+			key = ctx.GetKnownNamespace("Key", XamlContext.KnownNamespace_Xaml);
 			ctor = ctx.GetPseudoName("Ctor");
 
 			bool doWork;

--- a/Extensions/dnSpy.BamlDecompiler/Rewrite/MarkupExtensionRewritePass.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Rewrite/MarkupExtensionRewritePass.cs
@@ -79,7 +79,13 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 			if (attrName != key)
 				attrName = property.ToXName(ctx, parent, property.IsAttachedTo(type));
 			var attr = new XAttribute(attrName, extValue);
-			parent.Add(attr);
+			var list = new List<XAttribute>(parent.Attributes());
+			if (attrName == key)
+				list.Insert(0, attr);
+			else
+				list.Add(attr);
+			parent.RemoveAttributes();
+			parent.ReplaceAttributes(list);
 			elem.Remove();
 
 			return true;

--- a/Extensions/dnSpy.BamlDecompiler/Rewrite/XClassRewritePass.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Rewrite/XClassRewritePass.cs
@@ -48,11 +48,11 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 
 			elem.Name = xamlType.ToXName(ctx);
 
-			var attrName = ctx.GetXamlNsName("Class", elem);
+			var attrName = ctx.GetKnownNamespace("Class", XamlContext.KnownNamespace_Xaml, elem);
 
 			var attrs = elem.Attributes().ToList();
 			if (typeDef.IsNotPublic) {
-				var classModifierName = ctx.GetXamlNsName("ClassModifier", elem);
+				var classModifierName = ctx.GetKnownNamespace("ClassModifier", XamlContext.KnownNamespace_Xaml, elem);
 				attrs.Insert(0, new XAttribute(classModifierName, ctx.BamlDecompilerOptions.InternalClassModifier));
 			}
 			attrs.Insert(0, new XAttribute(attrName, type.ResolvedType.ReflectionFullName));

--- a/Extensions/dnSpy.BamlDecompiler/Xaml/XamlPathDeserializer.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Xaml/XamlPathDeserializer.cs
@@ -155,7 +155,7 @@ namespace dnSpy.BamlDecompiler.Xaml {
 						var size = ReadPoint(reader);
 						double angle = reader.ReadXamlDouble();
 
-						sb.AppendFormat(CultureInfo.InvariantCulture, "A{0} {2:R} {2} {3} {4}",
+						sb.AppendFormat(CultureInfo.InvariantCulture, "A{0} {1:R} {2} {3} {4}",
 							size, angle, largeArc ? '1' : '0', sweepDirection ? '1' : '0', pt1);
 						break;
 					}

--- a/Extensions/dnSpy.BamlDecompiler/Xaml/XamlProperty.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Xaml/XamlProperty.cs
@@ -79,13 +79,11 @@ namespace dnSpy.BamlDecompiler.Xaml {
 			XName name;
 			if (!isFullName)
 				name = XmlConvert.EncodeLocalName(PropertyName);
-			else
+			else {
 				name = typeName.LocalName + "." + XmlConvert.EncodeLocalName(PropertyName);
-
-			if (parent is null || (parent.GetDefaultNamespace() != typeName.Namespace &&
-			                       parent.Name.Namespace != typeName.Namespace))
-				name = typeName.Namespace + name.LocalName;
-
+				if (parent == null || parent.GetDefaultNamespace() != typeName.Namespace)
+					name = typeName.Namespace + name.LocalName;
+			}
 			return name;
 		}
 

--- a/Extensions/dnSpy.BamlDecompiler/Xaml/XamlUtils.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Xaml/XamlUtils.cs
@@ -41,11 +41,12 @@ namespace dnSpy.BamlDecompiler.Xaml {
 
 		public static string ToString(this XamlContext ctx, XElement elem, XName name) {
 			var sb = new StringBuilder();
-			if (name.Namespace != elem.GetDefaultNamespace() &&
-			    name.Namespace != elem.Name.Namespace &&
-			    !string.IsNullOrEmpty(name.Namespace.NamespaceName)) {
-				sb.Append(elem.GetPrefixOfNamespace(name.Namespace));
-				sb.Append(':');
+			if (name.Namespace != elem.GetDefaultNamespace()) {
+				var prefix = elem.GetPrefixOfNamespace(name.Namespace);
+				if (!string.IsNullOrEmpty(prefix)) {
+					sb.Append(prefix);
+					sb.Append(':');
+				}
 			}
 			sb.Append(name.LocalName);
 			return sb.ToString();

--- a/Extensions/dnSpy.BamlDecompiler/XamlContext.cs
+++ b/Extensions/dnSpy.BamlDecompiler/XamlContext.cs
@@ -173,6 +173,10 @@ namespace dnSpy.BamlDecompiler {
 			return ns;
 		}
 
+		public const string KnownNamespace_Xaml = "http://schemas.microsoft.com/winfx/2006/xaml";
+		public const string KnownNamespace_Presentation = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+		public const string KnownNamespace_PresentationOptions = "http://schemas.microsoft.com/winfx/2006/xaml/presentation/options";
+
 		public string TryGetXmlNamespace(IAssembly assembly, string typeNamespace) {
 			var asm = assembly as AssemblyDef;
 			if (asm is null)
@@ -194,16 +198,16 @@ namespace dnSpy.BamlDecompiler {
 					possibleXmlNs.Add(xmlNs);
 			}
 
-			if (possibleXmlNs.Contains("http://schemas.microsoft.com/winfx/2006/xaml/presentation"))
-				return "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+			if (possibleXmlNs.Contains(KnownNamespace_Presentation))
+				return KnownNamespace_Presentation;
 
 			return possibleXmlNs.FirstOrDefault();
 		}
 
-		public XName GetXamlNsName(string name, XElement elem = null) {
-			var xNs = GetXmlNamespace("http://schemas.microsoft.com/winfx/2006/xaml");
+		public XName GetKnownNamespace(string name, string xmlNamespace, XElement context = null) {
+			var xNs = GetXmlNamespace(xmlNamespace);
 			XName xName;
-			if (elem is not null && xNs == elem.GetDefaultNamespace())
+			if (context != null && xNs == context.GetDefaultNamespace())
 				xName = name;
 			else
 				xName = xNs + name;


### PR DESCRIPTION
This PR merges in the changes made by ICSharpCode team to the BAML decompiler for their ILSpy project(https://github.com/icsharpcode/ILSpy). Changes to ConnectionIdRewritePass haven't been merged as the code in the ILSpy repository depends on ICSharpCode.Decompiler version 3.