### PR TITLE
Fix nested archives in CI artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,47 +33,40 @@ jobs:
           $msbuildPath = Split-Path (& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find MSBuild\Current\Bin\amd64\MSBuild.exe | Select-Object -First 1) -Parent
           $env:PATH = $msbuildPath + ';' + $env:PATH
           .\build.ps1 netframework
-          New-Item -ItemType Directory -Path C:\builtfiles -Force > $null
-          Compress-Archive -Path dnSpy\dnSpy\bin\Release\net48\* -DestinationPath C:\builtfiles\dnSpy-netframework.zip
-          .\clean-all.cmd
-
-      - name: Build dnSpy (.NET x86)
-        shell: pwsh
-        run: |
-          $msbuildPath = Split-Path (& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find MSBuild\Current\Bin\amd64\MSBuild.exe | Select-Object -First 1) -Parent
-          $env:PATH = $msbuildPath + ';' + $env:PATH
-          .\build.ps1 net-x86
-          New-Item -ItemType Directory -Path C:\builtfiles -Force > $null
-          Compress-Archive -Path dnSpy\dnSpy\bin\Release\net5.0-windows\win-x86\publish\* -DestinationPath C:\builtfiles\dnSpy-net-win32.zip
-          .\clean-all.cmd
-
-      - name: Build dnSpy (.NET x64)
-        shell: pwsh
-        run: |
-          $msbuildPath = Split-Path (& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find MSBuild\Current\Bin\amd64\MSBuild.exe | Select-Object -First 1) -Parent
-          $env:PATH = $msbuildPath + ';' + $env:PATH
-          .\build.ps1 net-x64
-          New-Item -ItemType Directory -Path C:\builtfiles -Force > $null
-          Compress-Archive -Path dnSpy\dnSpy\bin\Release\net5.0-windows\win-x64\publish\* -DestinationPath C:\builtfiles\dnSpy-net-win64.zip
-          .\clean-all.cmd
-
+          
       - uses: actions/upload-artifact@v2
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         with:
           name: dnSpy-netframework
-          path: C:\builtfiles\dnSpy-netframework.zip
+          path: dnSpy\dnSpy\bin\Release\net48\*
           if-no-files-found: error
+
+      - name: Build dnSpy (.NET x86)
+        shell: pwsh
+        run: |
+          .\clean-all.cmd
+          $msbuildPath = Split-Path (& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find MSBuild\Current\Bin\amd64\MSBuild.exe | Select-Object -First 1) -Parent
+          $env:PATH = $msbuildPath + ';' + $env:PATH
+          .\build.ps1 net-x86
 
       - uses: actions/upload-artifact@v2
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         with:
           name: dnSpy-net-win32
-          path: C:\builtfiles\dnSpy-net-win32.zip
+          path: dnSpy\dnSpy\bin\Release\net5.0-windows\win-x86\publish\*
           if-no-files-found: error
+          
+      - name: Build dnSpy (.NET x64)
+        shell: pwsh
+        run: |
+          .\clean-all.cmd
+          $msbuildPath = Split-Path (& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find MSBuild\Current\Bin\amd64\MSBuild.exe | Select-Object -First 1) -Parent
+          $env:PATH = $msbuildPath + ';' + $env:PATH
+          .\build.ps1 net-x64
 
       - uses: actions/upload-artifact@v2
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         with:
           name: dnSpy-net-win64
-          path: C:\builtfiles\dnSpy-net-win64.zip
+          path:  dnSpy\dnSpy\bin\Release\net5.0-windows\win-x64\publish\*
           if-no-files-found: error


### PR DESCRIPTION
`actions/upload-artifact@v2` zips the given path, which is already a zip, resulting in nested zips in the artifacts. We can have `upload-artifact` run on the results instead, which requires moving the cleaning to the
next build and placing the uploads in-between as each build was removing all of its output aside from its created zip.