### PR TITLE
Show debugged process's name in titlebar info

### DIFF
--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/DbgUI/DebuggerImpl.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/DbgUI/DebuggerImpl.cs
@@ -406,6 +406,7 @@ namespace dnSpy.Debugger.DbgUI {
 			dbgManager.MessageUserMessage += DbgManager_MessageUserMessage;
 			dbgManager.MessageExceptionThrown += DbgManager_MessageExceptionThrown;
 			dbgManager.DbgManagerMessage += DbgManager_DbgManagerMessage;
+			dbgManager.ProcessesChanged += DbgManager_ProcessChanged;
 		}
 
 		void DbgManager_DbgManagerMessage(object? sender, DbgManagerMessageEventArgs e) {
@@ -430,6 +431,24 @@ namespace dnSpy.Debugger.DbgUI {
 				UI(() => ShowUnhandledException_UI(e));
 			}
 		}
+
+		void DbgManager_ProcessChanged(object? sender, DbgCollectionChangedEventArgs<DbgProcess> e) {
+			UI(() => {
+				string newProcessName = e.Objects[0].Name;
+
+				if (e.Added) {
+					if (oldProcessName is not null)
+						appWindow.Value.RemoveTitleInfo(oldProcessName);
+					appWindow.Value.AddTitleInfo(newProcessName);
+					oldProcessName = newProcessName;
+				}
+				else {
+					appWindow.Value.RemoveTitleInfo(newProcessName);
+					oldProcessName = null;
+				}
+			});
+		}
+		string? oldProcessName;
 
 		void UI(Action callback) => uiDispatcher.UI(callback);
 


### PR DESCRIPTION
Debugging multiple processes at once can sometimes get confusing. I found that this helped out a bit.

Example:
![image](https://user-images.githubusercontent.com/1909698/135699849-a80fd0de-75c9-4cbd-a32a-03add2eb76f3.png)

Taskbar info when hovering
![image](https://user-images.githubusercontent.com/1909698/135699904-b0fc8e61-e53a-487f-a88b-88aa5aff1241.png)
