### PR TITLE
Fix missing x:Static and x:Type in decompiled BAML

### DIFF
--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyWithExtensionHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyWithExtensionHandler.cs
@@ -42,7 +42,12 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			var ext = new XamlExtension(extType);
 			if (valTypeExt || extTypeId == (short)KnownTypes.TypeExtension) {
 				var value = ctx.ResolveType(record.ValueId);
-				ext.Initializer = new object[] { ctx.ToString(parent.Xaml, value) };
+
+				object[] initializer = new object[] { ctx.ToString(parent.Xaml, value) };
+				if (valTypeExt)
+					initializer = new object[] { new XamlExtension(ctx.ResolveType(0xfd4d)) { Initializer = initializer } }; // Known type - TypeExtension
+
+				ext.Initializer = initializer;
 			}
 			else if (extTypeId == (short)KnownTypes.TemplateBindingExtension) {
 				var value = ctx.ResolveProperty(record.ValueId);
@@ -85,7 +90,12 @@ namespace dnSpy.BamlDecompiler.Handlers {
 
 					attrName = ctx.ToString(parent.Xaml, xName);
 				}
-				ext.Initializer = new object[] { attrName };
+
+				object[] initializer = new object[] { attrName };
+				if (valStaticExt)
+					initializer = new object[] { new XamlExtension(ctx.ResolveType(0xfda6)) { Initializer = initializer } }; // Known type - StaticExtension
+
+				ext.Initializer = initializer;
 			}
 			else {
 				ext.Initializer = new object[] { XamlUtils.Escape(ctx.ResolveString(record.ValueId)) };


### PR DESCRIPTION
### **see https://github.com/icsharpcode/ILSpy/pull/2536**

> Link to issue(s) this covers
> https://github.com/icsharpcode/ILSpy/issues/2116
> 
> ### Problem
> issue https://github.com/icsharpcode/ILSpy/issues/2116 and another old pr https://github.com/icsharpcode/ILSpy/pull/2229
> 
> this also fixes missing x:Type
> 
> before:
> ![image](https://user-images.githubusercontent.com/27536652/140541389-69eb690e-ab79-4578-b184-6838018c1425.png)
> 
> after:
> ![image](https://user-images.githubusercontent.com/27536652/140541404-e079d47f-c8ac-4910-98b1-527619d30577.png)
