### PR TITLE
Support for loading/editing/saving .NET Core single file publish bundles. (#16)

### DIFF
--- a/Extensions/dnSpy.AsmEditor/Hex/Nodes/PETreeNodeDataProvider.cs
+++ b/Extensions/dnSpy.AsmEditor/Hex/Nodes/PETreeNodeDataProvider.cs
@@ -92,4 +92,12 @@ namespace dnSpy.AsmEditor.Hex.Nodes {
 			: base(hexBufferService, peStructureProviderFactory, hexBufferFileServiceFactory) {
 		}
 	}
+
+	[ExportTreeNodeDataProvider(Guid = DocumentTreeViewConstants.BUNDLE_NODE_GUID)]
+	sealed class BundleFilePETreeNodeDataProvider : PETreeNodeDataProviderBase {
+		[ImportingConstructor]
+		BundleFilePETreeNodeDataProvider(Lazy<IHexBufferService> hexBufferService, Lazy<PEStructureProviderFactory> peStructureProviderFactory, Lazy<HexBufferFileServiceFactory> hexBufferFileServiceFactory)
+			: base(hexBufferService, peStructureProviderFactory, hexBufferFileServiceFactory) {
+		}
+	}
 }

--- a/dnSpy/dnSpy.Contracts.DnSpy/Documents/BundleEntry.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Documents/BundleEntry.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using dnlib.IO;
+
+namespace dnSpy.Contracts.Documents {
+	/// <summary>
+	/// Represents one entry in a <see cref="SingleFileBundle"/>
+	/// </summary>
+	public sealed class BundleEntry {
+		/// <summary>
+		/// Type of the entry <seealso cref="BundleFileType"/>
+		/// </summary>
+		public BundleFileType Type { get; }
+
+		/// <summary>
+		/// Path of an embedded file, relative to the Bundle source-directory.
+		/// </summary>
+		public string RelativePath { get; }
+
+		/// <summary>
+		/// The raw data of the entry.
+		/// </summary>
+		public byte[] Data { get; }
+
+		BundleEntry(BundleFileType type, string relativePath, byte[] data) {
+			Type = type;
+			RelativePath = relativePath;
+			Data = data;
+		}
+
+		internal static IReadOnlyList<BundleEntry> ReadEntries(DataReader reader, int count, bool allowCompression) {
+			var res = new BundleEntry[count];
+
+			for (int i = 0; i < count; i++) {
+				long offset = reader.ReadInt64();
+				long size = reader.ReadInt64();
+				long compSize = allowCompression ? reader.ReadInt64() : 0;
+				var type = (BundleFileType)reader.ReadByte();
+				string path = reader.ReadSerializedString();
+
+				res[i] = new BundleEntry(type, path, ReadEntryData(reader, offset, size, compSize));
+			}
+
+			return res;
+		}
+
+		static byte[] ReadEntryData(DataReader reader, long offset, long size, long compSize) {
+			if (compSize == 0) {
+				reader.Position = (uint)offset;
+				return reader.ReadBytes((int)size);
+			}
+
+			using (var decompressedStream = new MemoryStream((int)size)) {
+				using (var compressedStream = reader.Slice((uint)offset, (uint)compSize).AsStream()) {
+					using (var deflateStream = new DeflateStream(compressedStream, CompressionMode.Decompress)) {
+						deflateStream.CopyTo(decompressedStream);
+						return decompressedStream.ToArray();
+					}
+				}
+			}
+		}
+	}
+}

--- a/dnSpy/dnSpy.Contracts.DnSpy/Documents/BundleFileType.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Documents/BundleFileType.cs
@@ -1,0 +1,39 @@
+﻿namespace dnSpy.Contracts.Documents {
+	/// <summary>
+	/// BundleFileType: Identifies the type of file embedded into the bundle.
+	///
+	/// The bundler differentiates a few kinds of files via the manifest,
+	/// with respect to the way in which they'll be used by the runtime.
+	/// </summary>
+	public enum BundleFileType : byte {
+		/// <summary>
+		/// Type not determined.
+		/// </summary>
+		Unknown,
+
+		/// <summary>
+		/// IL and R2R Assemblies
+		/// </summary>
+		Assembly,
+
+		/// <summary>
+		/// Native Binaries
+		/// </summary>
+		NativeBinary,
+
+		/// <summary>
+		/// .deps.json configuration file
+		/// </summary>
+		DepsJson,
+
+		/// <summary>
+		/// .runtimeconfig.json configuration file
+		/// </summary>
+		RuntimeConfigJson,
+
+		/// <summary>
+		/// PDB Files
+		/// </summary>
+		Symbols
+	}
+}

--- a/dnSpy/dnSpy.Contracts.DnSpy/Documents/DsDocument.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Documents/DsDocument.cs
@@ -39,6 +39,8 @@ namespace dnSpy.Contracts.Documents {
 		public virtual ModuleDef? ModuleDef => null;
 		/// <inheritdoc/>
 		public virtual IPEImage? PEImage => (ModuleDef as ModuleDefMD)?.Metadata?.PEImage;
+		/// <inheritdoc/>
+		public virtual SingleFileBundle? SingleFileBundle => null;
 
 		/// <inheritdoc/>
 		public string Filename {
@@ -322,7 +324,7 @@ namespace dnSpy.Contracts.Documents {
 		/// <summary>
 		/// The bundle represented by this document.
 		/// </summary>
-		public SingleFileBundle Bundle { get; }
+		public override SingleFileBundle? SingleFileBundle { get; }
 
 		ModuleCreationOptions opts;
 
@@ -334,16 +336,17 @@ namespace dnSpy.Contracts.Documents {
 		public DsBundleDocument(IPEImage peImage, SingleFileBundle bundle, ModuleCreationOptions options) {
 			PEImage = peImage;
 			Filename = peImage.Filename ?? string.Empty;
-			Bundle = bundle;
+			SingleFileBundle = bundle;
 			opts = options;
 		}
 
 		/// <inheritdoc/>
 		protected override TList<IDsDocument> CreateChildren() {
 			var list = new TList<IDsDocument>();
-			foreach (var entry in Bundle.Entries) {
+			foreach (var entry in SingleFileBundle!.Entries) {
 				if (entry.Type == BundleFileType.Assembly) {
-					list.Add(DsDotNetDocument.CreateAssembly(DsDocumentInfo.CreateInMemory(() => (entry.Data, true), null), ModuleDefMD.Load(entry.Data, opts), true));
+					list.Add(DsDotNetDocument.CreateAssembly(DsDocumentInfo.CreateInMemory(() => (entry.Data, true), null),
+						ModuleDefMD.Load(entry.Data, opts), true));
 				}
 			}
 

--- a/dnSpy/dnSpy.Contracts.DnSpy/Documents/IDsDocument.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Documents/IDsDocument.cs
@@ -56,6 +56,11 @@ namespace dnSpy.Contracts.Documents {
 		IPEImage? PEImage { get; }
 
 		/// <summary>
+		/// Gets the single file bundle descriptor or null if it's not a single file bundle.
+		/// </summary>
+		SingleFileBundle? SingleFileBundle { get; }
+
+		/// <summary>
 		/// Gets/sets the filename
 		/// </summary>
 		string Filename { get; set; }

--- a/dnSpy/dnSpy.Contracts.DnSpy/Documents/SingleFileBundle.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Documents/SingleFileBundle.cs
@@ -1,0 +1,133 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using dnlib.IO;
+using dnlib.PE;
+
+namespace dnSpy.Contracts.Documents {
+	/// <summary>
+	/// Class for dealing with .NET 5 single-file bundles.
+	///
+	/// Based on code from Microsoft.NET.HostModel.
+	/// </summary>
+	public sealed class SingleFileBundle {
+		static readonly byte[] bundleSignature = {
+			// 32 bytes represent the bundle signature: SHA-256 for ".net core bundle"
+			0x8b, 0x12, 0x02, 0xb9, 0x6a, 0x61, 0x20, 0x38,
+			0x72, 0x7b, 0x93, 0x02, 0x14, 0xd7, 0xa0, 0x32,
+			0x13, 0xf5, 0xb9, 0xe6, 0xef, 0xae, 0x33, 0x18,
+			0xee, 0x3b, 0x2d, 0xce, 0x24, 0xb3, 0x6a, 0xae
+		};
+
+		/// <summary>
+		/// The major version of the bundle.
+		/// </summary>
+		public uint MajorVersion { get; }
+
+		/// <summary>
+		/// The minor version of the bundle.
+		/// </summary>
+		public uint MinorVersion { get; }
+
+		/// <summary>
+		/// Number of entries in the bundle.
+		/// </summary>
+		public int EntryCount { get; }
+
+		/// <summary>
+		/// ID of the bundle.
+		/// </summary>
+		public string BundleID { get; }
+
+		/// <summary>
+		/// Offset of the embedded *.deps.json file.
+		/// Only present in version 2.0 and above.
+		/// </summary>
+		public long DepsJsonOffset { get; }
+
+		/// <summary>
+		/// Size of the embedded *.deps.json file.
+		/// Only present in version 2.0 and above.
+		/// </summary>
+		public long DepsJsonSize { get; }
+
+		/// <summary>
+		/// Offset of the embedded *.runtimeconfig.json file.
+		/// Only present in version 2.0 and above.
+		/// </summary>
+		public long RuntimeConfigJsonOffset { get; }
+
+		/// <summary>
+		/// Size of the embedded *.runtimeconfig.json file.
+		/// Only present in version 2.0 and above.
+		/// </summary>
+		public long RuntimeConfigJsonSize { get; }
+
+		/// <summary>
+		/// Bundle flags
+		/// Only present in version 2.0 and above.
+		/// </summary>
+		public ulong Flags { get; }
+
+		/// <summary>
+		/// The entries present in the bundle
+		/// </summary>
+		public IReadOnlyList<BundleEntry> Entries { get; }
+
+		SingleFileBundle(DataReader reader, uint major, uint minor) {
+			MajorVersion = major;
+			MinorVersion = minor;
+			EntryCount = reader.ReadInt32();
+			BundleID = reader.ReadSerializedString();
+			if (MajorVersion >= 2) {
+				DepsJsonOffset = reader.ReadInt64();
+				DepsJsonSize = reader.ReadInt64();
+				RuntimeConfigJsonOffset = reader.ReadInt64();
+				RuntimeConfigJsonSize = reader.ReadInt64();
+				Flags = reader.ReadUInt64();
+			}
+
+			Entries = BundleEntry.ReadEntries(reader, EntryCount, MajorVersion >= 6);
+		}
+
+		/// <summary>
+		/// Parses a bundle from the provided <see cref="IPEImage"/>
+		/// </summary>
+		/// <param name="peImage">The <see cref="IPEImage"/></param>
+		/// <returns>The <see cref="SingleFileBundle"/> or null if its not a bundle.</returns>
+		public static SingleFileBundle? FromPEImage(IPEImage peImage) {
+			if (!IsBundle(peImage, out long bundleHeaderOffset))
+				return null;
+			var reader = peImage.CreateReader();
+			reader.Position = (uint)bundleHeaderOffset;
+			uint major = reader.ReadUInt32();
+			if (major < 1 || major > 6)
+				return null;
+			uint minor = reader.ReadUInt32();
+			return new SingleFileBundle(reader, major, minor);
+		}
+
+		static bool IsBundle(IPEImage peImage, out long bundleHeaderOffset) {
+			var reader = peImage.CreateReader();
+
+			byte[] buffer = new byte[bundleSignature.Length];
+			uint end = reader.Length - (uint)bundleSignature.Length;
+			for (uint i = 0; i < end; i++) {
+				reader.Position = i;
+				buffer[0] = reader.ReadByte();
+				if (buffer[0] != 0x8b)
+					continue;
+				reader.ReadBytes(buffer, 1, bundleSignature.Length - 1);
+				if (!buffer.SequenceEqual(bundleSignature))
+					continue;
+				reader.Position = i - sizeof(long);
+				bundleHeaderOffset = reader.ReadInt64();
+				if (bundleHeaderOffset <= 0 || bundleHeaderOffset >= reader.Length)
+					continue;
+				return true;
+			}
+
+			bundleHeaderOffset = 0;
+			return false;
+		}
+	}
+}

--- a/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/BundleDocumentNode.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/BundleDocumentNode.cs
@@ -1,0 +1,14 @@
+﻿using System.Diagnostics;
+
+namespace dnSpy.Contracts.Documents.TreeView {
+	/// <summary>
+	/// A .NEt single file bundle.
+	/// </summary>
+	public abstract class BundleDocumentNode : DsDocumentNode {
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="document">Document</param>
+		protected BundleDocumentNode(IDsDocument document) : base(document) => Debug2.Assert(document.SingleFileBundle is not null);
+	}
+}

--- a/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/DocumentTreeViewConstants.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/DocumentTreeViewConstants.cs
@@ -45,6 +45,9 @@ namespace dnSpy.Contracts.Documents.TreeView {
 		/// <summary><see cref="ModuleDocumentNode"/></summary>
 		public const string MODULE_NODE_GUID = "597B3358-A6F5-47EA-B0D2-57EDD1208333";
 
+		/// <summary><see cref="BundleDocumentNode"/></summary>
+		public const string BUNDLE_NODE_GUID = "56ADC6DE-146D-4967-AE15-1F561CB61DFC";
+
 		/// <summary><see cref="ResourcesFolderNode"/></summary>
 		public const string RESOURCES_FOLDER_NODE_GUID = "1DD75445-9DED-482F-B6EB-4FD13E4A2197";
 

--- a/dnSpy/dnSpy/Documents/DsDocumentService.cs
+++ b/dnSpy/dnSpy/Documents/DsDocumentService.cs
@@ -445,6 +445,13 @@ namespace dnSpy.Documents {
 					}
 				}
 
+				var bundle = SingleFileBundle.FromPEImage(peImage);
+				if (bundle != null) {
+					var options = new ModuleCreationOptions(DsDotNetDocumentBase.CreateModuleContext(assemblyResolver));
+					options.TryToLoadPdbFromDisk = false;
+					return new DsBundleDocument(peImage, bundle, options);
+				}
+
 				return new DsPEDocument(peImage);
 			}
 			catch {

--- a/dnSpy/dnSpy/Documents/Tabs/NodeDecompiler.cs
+++ b/dnSpy/dnSpy/Documents/Tabs/NodeDecompiler.cs
@@ -54,6 +54,7 @@ namespace dnSpy.Documents.Tabs {
 		ResourceElementSet,
 		UnknownFile,
 		Message,
+		BundleFile
 	}
 
 	readonly struct NodeDecompiler {
@@ -171,6 +172,10 @@ namespace dnSpy.Documents.Tabs {
 				Decompile((MessageNode)node);
 				break;
 
+			case NodeType.BundleFile:
+				Decompile((BundleDocumentNode)node);
+				break;
+
 			default:
 				Debug.Fail($"Unknown NodeType: {nodeType}");
 				goto case NodeType.Unknown;
@@ -276,6 +281,25 @@ namespace dnSpy.Documents.Tabs {
 		void Decompile(UnknownDocumentNode node) => decompiler.WriteCommentLine(output, node.Document.Filename);
 		void Decompile(MessageNode node) => decompiler.WriteCommentLine(output, node.Message);
 
+		void Decompile(BundleDocumentNode node) {
+			decompiler.WriteCommentLine(output, node.Document.Filename);
+			var peImage = node.Document.PEImage;
+			if (peImage is not null) {
+				var timestampLine = dnSpy_Resources.Decompile_Timestamp + " ";
+				uint ts = peImage.ImageNTHeaders.FileHeader.TimeDateStamp;
+				if ((int)ts > 0) {
+					var date = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(ts).ToLocalTime();
+					var dateString = date.ToString(CultureInfo.CurrentUICulture.DateTimeFormat);
+					timestampLine += $"{ts:X8} ({dateString})";
+				}
+				else
+					timestampLine += $"{dnSpy_Resources.UnknownValue} ({ts:X8})";
+				decompiler.WriteCommentLine(output, timestampLine);
+			}
+
+			//TODO: Write information about the bundle.
+		}
+
 		static NodeType GetNodeType(DocumentTreeNodeData node) {
 			NodeType nodeType;
 			var type = node.GetType();
@@ -334,6 +358,8 @@ namespace dnSpy.Documents.Tabs {
 				return NodeType.UnknownFile;
 			if (node is MessageNode)
 				return NodeType.Message;
+			if (node is BundleDocumentNode)
+				return NodeType.BundleFile;
 
 			return NodeType.Unknown;
 		}

--- a/dnSpy/dnSpy/Documents/TreeView/BundleDocumentNodeImpl.cs
+++ b/dnSpy/dnSpy/Documents/TreeView/BundleDocumentNodeImpl.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using dnSpy.Contracts.Decompiler;
+using dnSpy.Contracts.Documents;
+using dnSpy.Contracts.Documents.TreeView;
+using dnSpy.Contracts.Images;
+using dnSpy.Contracts.Text;
+using dnSpy.Contracts.TreeView;
+using dnSpy.Decompiler;
+
+namespace dnSpy.Documents.TreeView {
+	sealed class BundleDocumentNodeImpl : BundleDocumentNode {
+		public BundleDocumentNodeImpl(IDsDocument document) : base(document) { }
+
+		public override Guid Guid => new Guid(DocumentTreeViewConstants.BUNDLE_NODE_GUID);
+
+		protected override ImageReference GetIcon(IDotNetImageService dnImgMgr) => dnImgMgr.GetImageReference(Document.PEImage!);
+
+		public override IEnumerable<TreeNodeData> CreateChildren() {
+			Debug2.Assert(Document.SingleFileBundle is not null);
+			foreach (var document in Document.Children)
+				yield return Context.DocumentTreeView.CreateNode(this, document);
+
+			// TODO: return all bundle entries
+		}
+
+		protected override void WriteCore(ITextColorWriter output, IDecompiler decompiler, DocumentNodeWriteOptions options) {
+			Debug2.Assert(Document.SingleFileBundle is not null);
+			Debug2.Assert(Document.PEImage is not null);
+			if ((options & DocumentNodeWriteOptions.ToolTip) == 0)
+				new NodeFormatter().Write(output, decompiler, Document);
+			else {
+				output.Write(BoxedTextColor.Text, TargetFrameworkUtils.GetArchString(Document.PEImage.ImageNTHeaders.FileHeader.Machine));
+
+				output.WriteLine();
+				output.WriteFilename(Document.Filename);
+			}
+		}
+
+		public override FilterType GetFilterType(IDocumentTreeNodeFilter filter) =>
+			filter.GetResult(Document).FilterType;
+	}
+}

--- a/dnSpy/dnSpy/Documents/TreeView/DefaultDsDocumentNodeProvider.cs
+++ b/dnSpy/dnSpy/Documents/TreeView/DefaultDsDocumentNodeProvider.cs
@@ -25,6 +25,11 @@ namespace dnSpy.Documents.TreeView {
 	[ExportDsDocumentNodeProvider(Order = double.MaxValue)]
 	sealed class DefaultDsDocumentNodeProvider : IDsDocumentNodeProvider {
 		public DsDocumentNode? Create(IDocumentTreeView documentTreeView, DsDocumentNode? owner, IDsDocument document) {
+			if (document is DsBundleDocument bundleDocument) {
+				Debug2.Assert(document.SingleFileBundle is not null);
+				return new BundleDocumentNodeImpl(bundleDocument);
+			}
+
 			if (document is IDsDotNetDocument dnDocument) {
 				Debug2.Assert(document.ModuleDef is not null);
 				if (document.AssemblyDef is null || owner is not null && owner.Document is not DsBundleDocument)

--- a/dnSpy/dnSpy/Documents/TreeView/DefaultDsDocumentNodeProvider.cs
+++ b/dnSpy/dnSpy/Documents/TreeView/DefaultDsDocumentNodeProvider.cs
@@ -27,7 +27,7 @@ namespace dnSpy.Documents.TreeView {
 		public DsDocumentNode? Create(IDocumentTreeView documentTreeView, DsDocumentNode? owner, IDsDocument document) {
 			if (document is IDsDotNetDocument dnDocument) {
 				Debug2.Assert(document.ModuleDef is not null);
-				if (document.AssemblyDef is null || owner is not null)
+				if (document.AssemblyDef is null || owner is not null && owner.Document is not DsBundleDocument)
 					return new ModuleDocumentNodeImpl(dnDocument);
 				return new AssemblyDocumentNodeImpl(dnDocument);
 			}

--- a/dnSpy/dnSpy/Documents/TreeView/DocumentTreeView.cs
+++ b/dnSpy/dnSpy/Documents/TreeView/DocumentTreeView.cs
@@ -473,6 +473,15 @@ namespace dnSpy.Documents.TreeView {
 					return n;
 			}
 
+			// Check for bundles
+			foreach (var n in TopNodes.OfType<BundleDocumentNode>()) {
+				n.TreeNode.EnsureChildrenLoaded();
+				foreach (var a in n.TreeNode.DataChildren.OfType<AssemblyDocumentNode>()) {
+					if (a.Document.AssemblyDef == asm)
+						return a;
+				}
+			}
+
 			return null;
 		}
 
@@ -492,6 +501,18 @@ namespace dnSpy.Documents.TreeView {
 			foreach (var n in TopNodes.OfType<ModuleDocumentNode>()) {
 				if (n.Document.ModuleDef == mod)
 					return n;
+			}
+
+			// Check for bundles
+			foreach (var n in TopNodes.OfType<BundleDocumentNode>()) {
+				n.TreeNode.EnsureChildrenLoaded();
+				foreach (var a in n.TreeNode.DataChildren.OfType<AssemblyDocumentNode>()) {
+					a.TreeNode.EnsureChildrenLoaded();
+					foreach (var m in a.TreeNode.DataChildren.OfType<ModuleDocumentNode>()) {
+						if (m.Document.ModuleDef == mod)
+							return m;
+					}
+				}
 			}
 
 			return null;
@@ -657,6 +678,18 @@ namespace dnSpy.Documents.TreeView {
 						if (c is ModuleDocumentNode modNode2)
 							yield return modNode2;
 					}
+					continue;
+				}
+
+				if (node is BundleDocumentNode bundleNode) {
+					bundleNode.TreeNode.EnsureChildrenLoaded();
+					foreach (var a in bundleNode.TreeNode.DataChildren.OfType<AssemblyDocumentNode>()) {
+						a.TreeNode.EnsureChildrenLoaded();
+						foreach (var m in a.TreeNode.DataChildren.OfType<ModuleDocumentNode>()) {
+							yield return m;
+						}
+					}
+
 					continue;
 				}
 			}


### PR DESCRIPTION
This PR aims to bring support for loading, editing, and saving .NET Core single file bundles.

Current implementation status:
dnSpy is able to display assembly entries of bundles and allows editing and saving said assemblies (excluding hex editor).

Roadmap:
- [ ] Fix AssemblyResolver to work properly for assemblies inside bundles.
- [ ] Iron out some of the remaining jump to reference bugs (e.g. namespaces).
- [ ] Pass the embedded symbol files to dnlib to provide additional information to decompiler.
- [ ] Add support for editing the single file bundle itself .
- [ ] Add support for showing all the other entries a bundle can have in the tree view.
- [ ] Add Hex editor support for the embedded assemblies.

Some of these regular dnSpy features require the file to be present in the filesystem. An example of such a feature is the Hex editor. I'm still debating whether support for this feature should be left out or should we write the extracted bundle entries to disk in a temporary location.

