### PR TITLE
Improvements to GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,9 @@ on:
     branches:
       - master
   release:
-    types: released
+    types:
+      - released
+  workflow_dispatch:
 
 env:
   CI_REQ_DOTNET_SDK_VER: 6.0.100
@@ -25,7 +27,7 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{env.CI_REQ_DOTNET_SDK_VER}}
-          
+
       - uses: microsoft/setup-msbuild@v1.0.2
 
       # Build each tfm separately since building all requires too much disk space
@@ -33,43 +35,43 @@ jobs:
         shell: pwsh
         run: |
           .\build.ps1 netframework
-          New-Item -ItemType Directory -Path C:\builtfiles -Force > $null
-          Compress-Archive -Path dnSpy\dnSpy\bin\Release\net48\* -DestinationPath C:\builtfiles\dnSpy-netframework.zip
+          New-Item -ItemType Directory -Path C:\builtfiles\dnSpy-netframework -Force > $null
+          Copy-Item -Path dnSpy\dnSpy\bin\Release\net48\* -Destination C:\builtfiles\dnSpy-netframework -Recurse
           .\clean-all.cmd
-          
+
       - uses: actions/upload-artifact@v2
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         with:
           name: dnSpy-netframework
-          path: C:\builtfiles\dnSpy-netframework.zip
+          path: C:\builtfiles\dnSpy-netframework
           if-no-files-found: error
 
       - name: Build dnSpy (.NET x86)
         shell: pwsh
         run: |
           .\build.ps1 net-x86
-          New-Item -ItemType Directory -Path C:\builtfiles -Force > $null
-          Compress-Archive -Path dnSpy\dnSpy\bin\Release\net6.0-windows\win-x86\publish\* -DestinationPath C:\builtfiles\dnSpy-net-win32.zip
+          New-Item -ItemType Directory -Path C:\builtfiles\dnSpy-net-win32 -Force > $null
+          Copy-Item -Path dnSpy\dnSpy\bin\Release\net6.0-windows\win-x86\publish\* -Destination C:\builtfiles\dnSpy-net-win32 -Recurse
           .\clean-all.cmd
 
       - uses: actions/upload-artifact@v2
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         with:
           name: dnSpy-net-win32
-          path: C:\builtfiles\dnSpy-net-win32.zip
+          path: C:\builtfiles\dnSpy-net-win32
           if-no-files-found: error
-          
+
       - name: Build dnSpy (.NET x64)
         shell: pwsh
         run: |
           .\build.ps1 net-x64
-          New-Item -ItemType Directory -Path C:\builtfiles -Force > $null
-          Compress-Archive -Path dnSpy\dnSpy\bin\Release\net6.0-windows\win-x64\publish\* -DestinationPath C:\builtfiles\dnSpy-net-win64.zip
+          New-Item -ItemType Directory -Path C:\builtfiles\dnSpy-net-win64 -Force > $null
+          Copy-Item -Path dnSpy\dnSpy\bin\Release\net6.0-windows\win-x64\publish\* -Destination C:\builtfiles\dnSpy-net-win64 -Recurse
           .\clean-all.cmd
 
       - uses: actions/upload-artifact@v2
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         with:
           name: dnSpy-net-win64
-          path: C:\builtfiles\dnSpy-net-win64.zip
+          path: C:\builtfiles\dnSpy-net-win64
           if-no-files-found: error


### PR DESCRIPTION
This does a few minor things

- Fixes `on.release.types` to be an array like defined in the [spec](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release)
- Adds the `workflow_dispatch` trigger, which allows repository maintainers to manually trigger the workflow against any branch or tag. This is helpful for forks because it allows non-master branches to be tested by Actions before opening a pull request.
- Adjusts the workflow script to make `upload_artifact` pack from a folder instead of a zip. This avoids the annoying zip-inside-zip side effect that somehow [still hasn't been fixed](https://github.com/actions/upload-artifact/issues/39).