### PR TITLE
Search component improvements

### DIFF
--- a/dnSpy/dnSpy.Contracts.DnSpy/Search/BodyResult.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Search/BodyResult.cs
@@ -17,6 +17,8 @@
     along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using dnlib.DotNet.Emit;
+
 namespace dnSpy.Contracts.Search {
 	/// <summary>
 	/// Stored in <see cref="ISearchResult.Object"/> if the method body was searched
@@ -28,17 +30,24 @@ namespace dnSpy.Contracts.Search {
 		public uint ILOffset { get; }
 
 		/// <summary>
+		/// OpCode of instruction referencing the constant
+		/// </summary>
+		public OpCode OpCode { get; }
+
+		/// <summary>
 		/// Operand of instruction referencing the constant
 		/// </summary>
-		public object Operand { get; }
+		public object? Operand { get; }
 
 		/// <summary>
 		/// Constructor
 		/// </summary>
 		/// <param name="ilOffset">IL offset of instruction</param>
+		/// <param name="opCode">OpCode of instruction</param>
 		/// <param name="operand">Operand of instruction</param>
-		public BodyResult(uint ilOffset, object operand) {
+		public BodyResult(uint ilOffset, OpCode opCode, object? operand) {
 			ILOffset = ilOffset;
+			OpCode = opCode;
 			Operand = operand;
 		}
 	}

--- a/dnSpy/dnSpy.Contracts.DnSpy/Search/BodyResult.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Search/BodyResult.cs
@@ -28,9 +28,18 @@ namespace dnSpy.Contracts.Search {
 		public uint ILOffset { get; }
 
 		/// <summary>
+		/// Operand of instruction referencing the constant
+		/// </summary>
+		public object Operand { get; }
+
+		/// <summary>
 		/// Constructor
 		/// </summary>
 		/// <param name="ilOffset">IL offset of instruction</param>
-		public BodyResult(uint ilOffset) => ILOffset = ilOffset;
+		/// <param name="operand">Operand of instruction</param>
+		public BodyResult(uint ilOffset, object operand) {
+			ILOffset = ilOffset;
+			Operand = operand;
+		}
 	}
 }

--- a/dnSpy/dnSpy/Search/FilterSearcher.cs
+++ b/dnSpy/dnSpy/Search/FilterSearcher.cs
@@ -664,6 +664,9 @@ namespace dnSpy.Search {
 					return true;
 			}
 
+			if (field.Constant is not null && IsMatch(null, field.Constant.Value))
+				return true;
+
 			return false;
 		}
 

--- a/dnSpy/dnSpy/Search/FilterSearcher.cs
+++ b/dnSpy/dnSpy/Search/FilterSearcher.cs
@@ -639,7 +639,7 @@ namespace dnSpy.Search {
 						LocationObject = type,
 						LocationImageReference = options.DotNetImageService.GetImageReference(type),
 						Document = ownerModule,
-						ObjectInfo = new BodyResult(instr.Offset),
+						ObjectInfo = new BodyResult(instr.Offset, operand),
 					});
 					break;
 				}

--- a/dnSpy/dnSpy/Search/FilterSearcher.cs
+++ b/dnSpy/dnSpy/Search/FilterSearcher.cs
@@ -648,7 +648,7 @@ namespace dnSpy.Search {
 						LocationObject = type,
 						LocationImageReference = options.DotNetImageService.GetImageReference(type),
 						Document = ownerModule,
-						ObjectInfo = new BodyResult(instr.Offset, operand),
+						ObjectInfo = new BodyResult(instr.Offset, instr.OpCode, instr.Operand),
 					});
 					break;
 				}

--- a/dnSpy/dnSpy/Search/FilterSearcher.cs
+++ b/dnSpy/dnSpy/Search/FilterSearcher.cs
@@ -85,8 +85,17 @@ namespace dnSpy.Search {
 
 		bool CheckCA(IDsDocument file, IHasCustomAttribute hca, object? parent, CAArgument o) {
 			var value = o.Value;
-			var u = value as UTF8String;
-			if (u is not null)
+			if (value is IList<CAArgument> array) {
+				foreach (var caArgument in array) {
+					if (CheckCA(file, hca, parent, caArgument))
+						return true;
+				}
+			}
+			else if (value is CAArgument boxed) {
+				if (CheckCA(file, hca, parent, boxed))
+					return true;
+			}
+			else if (value is UTF8String u)
 				value = u.String;
 			if (!IsMatch(null, value))
 				return false;

--- a/dnSpy/dnSpy/Search/SearchResult.cs
+++ b/dnSpy/dnSpy/Search/SearchResult.cs
@@ -111,6 +111,8 @@ namespace dnSpy.Search {
 			}
 		}
 
+		const FormatterOptions DefaultFormatterOptions = FormatterOptions.Default & ~(FormatterOptions.ShowParameterNames | FormatterOptions.ShowDeclaringTypes | FormatterOptions.ShowFieldLiteralValues);
+
 		void CreateUI(ITextColorWriter output, object? o, bool includeNamespace) {
 			if (o is NamespaceSearchResult ns) {
 				output.WriteNamespace(ns.Namespace);
@@ -124,29 +126,20 @@ namespace dnSpy.Search {
 			}
 
 			if (o is MethodDef md) {
-				var methodNameColor = Context.Decompiler.MetadataTextColorProvider.GetColor(md);
-				output.Write(methodNameColor, IdentifierEscaper.Escape(md.Name));
+				Debug2.Assert(Context.Decompiler is not null);
+				Context.Decompiler.Write(output, md, DefaultFormatterOptions);
 				if (md.ImplMap is ImplMap implMap && !UTF8String.IsNullOrEmpty(implMap.Name) && implMap.Name != md.Name) {
 					output.WriteSpace();
 					output.Write(BoxedTextColor.Punctuation, "(");
-					output.Write(methodNameColor, IdentifierEscaper.Escape(implMap.Name));
+					output.Write(Context.Decompiler.MetadataTextColorProvider.GetColor(md), IdentifierEscaper.Escape(implMap.Name));
 					output.Write(BoxedTextColor.Punctuation, ")");
 				}
 				return;
 			}
 
-			if (o is FieldDef fd) {
-				output.Write(Context.Decompiler.MetadataTextColorProvider.GetColor(fd), IdentifierEscaper.Escape(fd.Name));
-				return;
-			}
-
-			if (o is PropertyDef pd) {
-				output.Write(Context.Decompiler.MetadataTextColorProvider.GetColor(pd), IdentifierEscaper.Escape(pd.Name));
-				return;
-			}
-
-			if (o is EventDef ed) {
-				output.Write(Context.Decompiler.MetadataTextColorProvider.GetColor(ed), IdentifierEscaper.Escape(ed.Name));
+			if (o is IMemberDef memberDef) {
+				Debug2.Assert(Context.Decompiler is not null);
+				Context.Decompiler.Write(output, memberDef, DefaultFormatterOptions);
 				return;
 			}
 

--- a/dnSpy/dnSpy/Search/SearchResult.cs
+++ b/dnSpy/dnSpy/Search/SearchResult.cs
@@ -66,24 +66,7 @@ namespace dnSpy.Search {
 			OnPropertyChanged(nameof(ToolTip));
 		}
 
-		public string? ToolTip {
-			get {
-				var dsDocument = Document;
-				if (dsDocument is null)
-					return null;
-				var module = dsDocument.ModuleDef;
-				if (module is null)
-					return dsDocument.Filename;
-				if (!string.IsNullOrWhiteSpace(module.Location))
-					return module.Location;
-				if (!string.IsNullOrWhiteSpace(module.Name))
-					return module.Name;
-				if (module.Assembly is not null && !string.IsNullOrWhiteSpace(module.Assembly.Name))
-					return module.Assembly.Name;
-				return null;
-			}
-		}
-
+		public object ToolTip => CreateToolTipUI(NameObject);
 		public object NameUI => CreateUI(NameObject, false);
 		public object? LocationUI => CreateUI(LocationObject, true);
 
@@ -190,6 +173,83 @@ namespace dnSpy.Search {
 			}
 
 			Debug2.Assert(o is null);
+		}
+
+		object CreateToolTipUI(object? o) {
+			var writer = Cache.GetWriter();
+			try {
+				CreateToolTipUI(writer, o);
+				var context = new TextClassifierContext(writer.Text, string.Empty, Context.SyntaxHighlight, writer.Colors);
+				return Context.TextElementProvider.CreateTextElement(Context.ClassificationFormatMap, context, ContentTypes.Search, TextElementFlags.None);
+			}
+			finally {
+				Cache.FreeWriter(writer);
+			}
+		}
+
+		void CreateToolTipUI(ITextColorWriter output, object? o) {
+			if (o is NamespaceSearchResult ns)
+				output.WriteNamespace(ns.Namespace);
+			else if (o is TypeDef td) {
+				Debug2.Assert(Context.Decompiler is not null);
+				Context.Decompiler.WriteType(output, td, false);
+			}
+			else if (o is IMemberDef md) {
+				Debug2.Assert(Context.Decompiler is not null);
+				Context.Decompiler.WriteToolTip(output, md, md.DeclaringType);
+				if (ObjectInfo is BodyResult bodyResult) {
+					output.WriteLine();
+					// TODO: better printing of floating point operands.
+					var operandColor = Context.Decompiler.MetadataTextColorProvider.GetColor(bodyResult.Operand);
+					output.Write(operandColor, IdentifierEscaper.Escape(bodyResult.Operand.ToString()));
+					// TODO: localize
+					output.Write(BoxedTextColor.Text, " at ");
+					output.Write(BoxedTextColor.Label, "IL_");
+					output.Write(BoxedTextColor.Label, bodyResult.ILOffset.ToString("X4"));
+				}
+			}
+			else if (o is AssemblyDef asm)
+				output.Write(asm);
+			else if (o is ModuleDef mod)
+				output.WriteModule(mod.FullName);
+			else if (o is AssemblyRef asmRef)
+				output.Write(asmRef);
+			else if (o is ModuleRef modRef)
+				output.WriteModule(modRef.FullName);
+			else if (o is ParamDef paramDef)
+				output.Write(BoxedTextColor.Parameter, IdentifierEscaper.Escape(paramDef.Name));
+			else if (o is IDsDocument document) // non-.NET file
+				output.Write(BoxedTextColor.Text, document.GetShortName());
+			else if (o is ResourceNode resNode)
+				output.WriteFilename(resNode.Name);
+			else if (o is ResourceElementNode resElNode)
+				output.WriteFilename(resElNode.Name);
+			else if (o is ErrorMessage em)
+				output.Write(em.Color, em.Text);
+			else
+				Debug2.Assert(o is null);
+
+			var asmLocation = GetAssemblyLocation();
+			if (asmLocation is not null) {
+				output.WriteLine();
+				output.WriteFilename(asmLocation);
+			}
+		}
+
+		string? GetAssemblyLocation() {
+			var dsDocument = Document;
+			if (dsDocument is null)
+				return null;
+			var module = dsDocument.ModuleDef;
+			if (module is null)
+				return dsDocument.Filename;
+			if (!string.IsNullOrWhiteSpace(module.Location))
+				return module.Location;
+			if (!string.IsNullOrWhiteSpace(module.Name))
+				return module.Name;
+			if (module.Assembly is not null && !string.IsNullOrWhiteSpace(module.Assembly.Name))
+				return module.Assembly.Name;
+			return null;
 		}
 
 		public static SearchResult CreateMessage(SearchResultContext context, string msg, object color, bool first) =>


### PR DESCRIPTION
This PR brings the following:
- Better detection of string and integer constants when searching - Searching of field constant values has been implemented and the searching of custom attributes has been extended. In practice, this means that the search component now scans the values of `const` fields as well as fields belonging to enums.
- The results list view now contains member signatures instead of just names
![image](https://user-images.githubusercontent.com/37494960/176424241-37537151-a8d5-4677-a6a0-48384f816066.png)
- Made the tooltips on the search results more useful:
Before this PR every tooltip just contained the location of the assembly in which the result exists:
![image](https://user-images.githubusercontent.com/37494960/176424621-c43201e6-b1b3-4d83-a838-8b3586f8b0c0.png)
Tooltips after the changes made in this PR contain detailed information on the search result:
![image](https://user-images.githubusercontent.com/37494960/176424916-215ce0a8-9379-4846-8c1b-df88513cd00f.png)
If the user is searching for a constant the tooltip also contains the instruction which matched the search result:
![image](https://user-images.githubusercontent.com/37494960/176425060-8bd03eae-9502-49db-901e-394e9d3342cc.png)

Feedback on these changes is welcome :)