### PR TITLE
Fix exception on accessing dynamic memory module that has no path

### DIFF
--- a/dnSpy/dnSpy.Contracts.Logic/Utilities/FrameworkFileUtils.cs
+++ b/dnSpy/dnSpy.Contracts.Logic/Utilities/FrameworkFileUtils.cs
@@ -464,7 +464,7 @@ namespace dnSpy.Contracts.Utilities {
 		/// <returns></returns>
 		public static bool IsFrameworkAssembly(string filename, string? assemblySimpleName) {
 			// Check if it's in one of the .NET runtime dirs
-			if (Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(filename))) is string baseDir && Directory.Exists(Path.Combine(baseDir, "Microsoft.NETCore.App")))
+			if (!string2.IsNullOrWhiteSpace(filename) && Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(filename))) is string baseDir && Directory.Exists(Path.Combine(baseDir, "Microsoft.NETCore.App")))
 				return true;
 
 			if (assemblySimpleName is not null) {
@@ -477,7 +477,7 @@ namespace dnSpy.Contracts.Utilities {
 			}
 
 			// .NET Framework
-			if (GacInfo.IsGacPath(filename))
+			if (!string2.IsNullOrWhiteSpace(filename) && GacInfo.IsGacPath(filename))
 				return true;
 
 			return false;


### PR DESCRIPTION
If a dynamic resource is accessed for searching (including auto searches) IsFrameworkAssembly is called which will throw an exception.  It throws invalid path if the resource has no filename.  