### PR TITLE
Fix: GitHub build workflow now will error on fail and use matrix configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,22 @@ jobs:
   build:
     name: Build
     runs-on: windows-2022
+    defaults:
+        run:
+          shell: pwsh
+    strategy:
+      matrix:
+        platform: [netframework, net-x86, net-x64]
+        include:
+          - platform: netframework
+            package-name: netframework
+            build-dir: net48
+          - platform: net-x86
+            package-name: net-win32
+            build-dir: net6.0-windows\win-x86\publish
+          - platform: net-x64
+            package-name: net-win64
+            build-dir: net6.0-windows\win-x64\publish
 
     steps:
       - uses: actions/checkout@v2
@@ -31,47 +47,17 @@ jobs:
       - uses: microsoft/setup-msbuild@v1.0.2
 
       # Build each tfm separately since building all requires too much disk space
-      - name: Build dnSpy (.NET Framework)
-        shell: pwsh
-        run: |
-          .\build.ps1 netframework
-          New-Item -ItemType Directory -Path C:\builtfiles\dnSpy-netframework -Force > $null
-          Copy-Item -Path dnSpy\dnSpy\bin\Release\net48\* -Destination C:\builtfiles\dnSpy-netframework -Recurse
-          .\clean-all.cmd
+      - name: Build dnSpy (${{matrix.platform}})
+        run: .\build.ps1 ${{matrix.platform}}
+      - name: Create output directory
+        run: New-Item -ItemType Directory -Path C:\builtfiles\dnSpy-${{matrix.platform}} -Force > $null
+        continue-on-error: true
+      - name:  Copy release files for upload
+        run: Copy-Item -Path dnSpy\dnSpy\bin\Release\${{matrix.build-dir}}\* -Destination C:\builtfiles\dnSpy-${{matrix.platform}} -Recurse
 
       - uses: actions/upload-artifact@v2
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         with:
-          name: dnSpy-netframework
-          path: C:\builtfiles\dnSpy-netframework
-          if-no-files-found: error
-
-      - name: Build dnSpy (.NET x86)
-        shell: pwsh
-        run: |
-          .\build.ps1 net-x86
-          New-Item -ItemType Directory -Path C:\builtfiles\dnSpy-net-win32 -Force > $null
-          Copy-Item -Path dnSpy\dnSpy\bin\Release\net6.0-windows\win-x86\publish\* -Destination C:\builtfiles\dnSpy-net-win32 -Recurse
-          .\clean-all.cmd
-
-      - uses: actions/upload-artifact@v2
-        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
-        with:
-          name: dnSpy-net-win32
-          path: C:\builtfiles\dnSpy-net-win32
-          if-no-files-found: error
-
-      - name: Build dnSpy (.NET x64)
-        shell: pwsh
-        run: |
-          .\build.ps1 net-x64
-          New-Item -ItemType Directory -Path C:\builtfiles\dnSpy-net-win64 -Force > $null
-          Copy-Item -Path dnSpy\dnSpy\bin\Release\net6.0-windows\win-x64\publish\* -Destination C:\builtfiles\dnSpy-net-win64 -Recurse
-          .\clean-all.cmd
-
-      - uses: actions/upload-artifact@v2
-        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
-        with:
-          name: dnSpy-net-win64
-          path: C:\builtfiles\dnSpy-net-win64
+          name: dnSpy-${{matrix.package-name}}
+          path: C:\builtfiles\dnSpy-${{matrix.platform}}
           if-no-files-found: error

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,8 @@
-param([string]$buildtfm = 'all', [switch]$NoMsbuild)
+param(
+	[ValidateSet("all","netframework","net-x86","net-x64")]
+	[string]$buildtfm = 'all',
+	[switch]$NoMsbuild
+	)
 $ErrorActionPreference = 'Stop'
 
 $netframework_tfm = 'net48'


### PR DESCRIPTION
Fixes #86
Build script will also throw error now if invalid arch specified.

While checking to make sure the exe builds that seemed like more of a hack, as the build process itself was erroring out but GH actions was thinking that step was a success. 


 I don't use GH actions much either but after some tracing it was apparent.  The build script calls the pwsh shell and passes multiple commands to it.   PWSH will only return the exit code of the entire command it is running but not fail if one of the exit codes is non-zero. 

 There was no apparent option to fix this, could move the commands for a step to a powershell file and then use `$ErrorActionPreference = 'Stop'` but would still need to check the exit code for any non-powershell calls manually.

 Instead I just converted each step to run a single command which should have the desired result.

 A quick test seems to work: https://github.com/mitchcapper/dnSpy/actions/runs/2654844926
 
In addition by switching to the matrix configuration builds will complete 3x faster and no need for the cleanup in between as jobs each have their own parallel runner.


