### PR TITLE
WIP: Add option to close all framework assemblies to the menu

### DIFF
--- a/Extensions/dnSpy.AsmEditor/Commands/CloseAllFrameworkAssembliesCommand.cs
+++ b/Extensions/dnSpy.AsmEditor/Commands/CloseAllFrameworkAssembliesCommand.cs
@@ -1,0 +1,64 @@
+/*
+    Copyright (C) 2014-2019 de4dot@gmail.com
+
+    This file is part of dnSpy
+
+    dnSpy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    dnSpy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using dnSpy.AsmEditor.Assembly;
+using dnSpy.AsmEditor.SaveModule;
+using dnSpy.AsmEditor.UndoRedo;
+using dnSpy.Contracts.Documents.TreeView;
+using dnSpy.Contracts.Menus;
+using dnSpy.Contracts.Utilities;
+
+namespace dnSpy.AsmEditor.Commands {
+	[ExportMenuItem(OwnerGuid = MenuConstants.APP_MENU_FILE_GUID, Header = "Close All Framework Assemblies", Group = MenuConstants.GROUP_APP_MENU_FILE_OPEN, Order = 55)]
+	sealed class CloseAllFrameworkAssembliesCommand : MenuItemBase {
+		readonly IDocumentTreeView documentTreeView;
+		readonly Lazy<IUndoCommandService> undoCommandService;
+		readonly Lazy<IDocumentSaver> documentSaver;
+		readonly IAppService appService;
+
+		[ImportingConstructor]
+		CloseAllFrameworkAssembliesCommand(IDocumentTreeView documentTreeView, Lazy<IUndoCommandService> undoCommandService, Lazy<IDocumentSaver> documentSaver, IAppService appService) {
+			this.documentTreeView = documentTreeView;
+			this.undoCommandService = undoCommandService;
+			this.documentSaver = documentSaver;
+			this.appService = appService;
+		}
+		AssemblyDocumentNode[]? GetNodes() {
+			var nodes = new List<AssemblyDocumentNode>();
+			foreach (var node in documentTreeView.TreeView.Root.DataChildren.OfType<AssemblyDocumentNode>()) {
+				var doc = node.Document;
+				if (!node.IsExe && FrameworkFileUtils.IsFrameworkAssembly(doc.Filename, doc.AssemblyDef?.Name?.ToString()))
+					nodes.Add(node);
+			}
+
+			return nodes.Count == 0 ? null : nodes.ToArray();
+		}
+
+		public override bool IsEnabled(IMenuItemContext context) => GetNodes() is not null;
+		public override void Execute(IMenuItemContext context) {
+			var nodes = GetNodes();
+			if (nodes is not null)
+				RemoveAssemblyCommand.Execute(undoCommandService, documentSaver, appService, nodes);
+		}
+	}
+}


### PR DESCRIPTION
I figured adding a close framework assemblies option would be nice to quickly clean the ASM tree up.  Sadly I couldn't figure out how to do this well.  Clearly reflection isnt the right way but I didn't really see any projects that would include all the functions needed.

The two biggies i was trying to avoid was copying code for:
IsFrameworkAssembly
and avoid copying the code for  RemoveAssemblyCommand and the undo logic that dnSpy.asmeditor has.