### PR TITLE
Feature: Export inner exceptions to dnSpy

### DIFF
--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Metadata/DmdType.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Metadata/DmdType.cs
@@ -772,6 +772,16 @@ namespace dnSpy.Debugger.DotNet.Metadata {
 		public abstract DmdFieldInfo? GetField(string name, DmdBindingFlags bindingAttr);
 
 		/// <summary>
+		/// Gets a field
+		/// </summary>
+		/// <param name="name">Name</param>
+		/// <param name="bindingAttr">Binding flags</param>
+		/// <param name="allowTypeVarianceOnPrivateFields">Allow the reflected type to not equal the declared type</param>
+		/// 
+		/// <returns></returns>
+		public abstract DmdFieldInfo? GetField(string name, DmdBindingFlags bindingAttr, bool allowTypeVarianceOnPrivateFields);
+
+		/// <summary>
 		/// Gets a public static or instance field
 		/// </summary>
 		/// <param name="name">Name</param>

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Metadata/Impl/DmdMemberInfoComparer.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Metadata/Impl/DmdMemberInfoComparer.cs
@@ -31,7 +31,7 @@ namespace dnSpy.Debugger.DotNet.Metadata.Impl {
 			return (attr & bindingAttr) == attr;
 		}
 
-		public static bool IsMatch(DmdMethodBase method, DmdBindingFlags bindingAttr) {
+		public static bool IsMatch(DmdMethodBase method, DmdBindingFlags bindingAttr, bool allowTypeVarianceOnPrivateFields = false) {
 			var attr = DmdBindingFlags.Default;
 			if (method.IsPublic)
 				attr |= DmdBindingFlags.Public;
@@ -48,14 +48,14 @@ namespace dnSpy.Debugger.DotNet.Metadata.Impl {
 					attr |= DmdBindingFlags.FlattenHierarchy;
 				}
 				else {
-					if (!(method.IsVirtual || method.IsAbstract) && method.IsPrivate)
+					if (!(method.IsVirtual || method.IsAbstract) && method.IsPrivate && !allowTypeVarianceOnPrivateFields)
 						return false;
 				}
 			}
 			return (attr & bindingAttr) == attr;
 		}
 
-		public static bool IsMatch(DmdFieldInfo field, DmdBindingFlags bindingAttr) {
+		public static bool IsMatch(DmdFieldInfo field, DmdBindingFlags bindingAttr, bool allowTypeVarianceOnPrivateFields=false) {
 			var attr = DmdBindingFlags.Default;
 			if (field.IsPublic)
 				attr |= DmdBindingFlags.Public;
@@ -72,7 +72,7 @@ namespace dnSpy.Debugger.DotNet.Metadata.Impl {
 					attr |= DmdBindingFlags.FlattenHierarchy;
 				}
 				else {
-					if (field.IsPrivate)
+					if (field.IsPrivate && !allowTypeVarianceOnPrivateFields)
 						return false;
 				}
 			}
@@ -106,7 +106,7 @@ namespace dnSpy.Debugger.DotNet.Metadata.Impl {
 			return (attr & bindingAttr) == attr;
 		}
 
-		public static bool IsMatch(DmdPropertyInfo property, DmdBindingFlags bindingAttr) {
+		public static bool IsMatch(DmdPropertyInfo property, DmdBindingFlags bindingAttr, bool allowTypeVarianceOnPrivateFields = false) {
 			var attr = DmdBindingFlags.Default;
 			if (property.GetMethod?.IsPublic == true || property.SetMethod?.IsPublic == true)
 				attr |= DmdBindingFlags.Public;
@@ -125,7 +125,7 @@ namespace dnSpy.Debugger.DotNet.Metadata.Impl {
 						attr |= DmdBindingFlags.FlattenHierarchy;
 					}
 					else {
-						if (!(method.IsVirtual || method.IsAbstract) && method.IsPrivate)
+						if (!(method.IsVirtual || method.IsAbstract) && method.IsPrivate && ! allowTypeVarianceOnPrivateFields)
 							return false;
 					}
 				}

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Metadata/Impl/DmdTypeBase.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Metadata/Impl/DmdTypeBase.cs
@@ -164,12 +164,12 @@ namespace dnSpy.Debugger.DotNet.Metadata.Impl {
 			}
 			return methods?.ToArray() ?? Array.Empty<DmdMethodInfo>();
 		}
-
-		public sealed override DmdFieldInfo? GetField(string name, DmdBindingFlags bindingAttr) {
+		public sealed override DmdFieldInfo? GetField(string name, DmdBindingFlags bindingAttr) => GetField(name, bindingAttr, false);
+		public sealed override DmdFieldInfo? GetField(string name, DmdBindingFlags bindingAttr, bool allowTypeVarianceOnPrivateFields) {
 			if (name is null)
 				throw new ArgumentNullException(nameof(name));
 			foreach (var field in GetFields(ToGetMemberOptions(bindingAttr))) {
-				if (DmdMemberInfoComparer.IsMatch(field, name, bindingAttr) && DmdMemberInfoComparer.IsMatch(field, bindingAttr))
+				if (DmdMemberInfoComparer.IsMatch(field, name, bindingAttr) && DmdMemberInfoComparer.IsMatch(field, bindingAttr, allowTypeVarianceOnPrivateFields))
 					return field;
 			}
 			return null;

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Metadata/KnownMemberNames.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Metadata/KnownMemberNames.cs
@@ -54,6 +54,7 @@ namespace dnSpy.Debugger.DotNet.Metadata {
 		// System.Exception
 		public const string Exception_Message_FieldName = "_message";
 		public const string Exception_Message_FieldName_Mono = "message";
+		public const string Exception_InnerException_FieldName = "_innerException";
 		public const string Exception_HResult_FieldName = "_HResult";
 
 		// System.Threading.Thread

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/DbgUI/DebuggerImpl.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/DbgUI/DebuggerImpl.cs
@@ -551,9 +551,20 @@ namespace dnSpy.Debugger.DbgUI {
 				case DbgMessageKind.ExceptionThrown:
 					var ex = ((DbgMessageExceptionThrownEventArgs)e).Exception;
 					var exMsg = ex.IsUnhandled ? dnSpy_Debugger_Resources.Debug_EventDescription_UnhandledException : dnSpy_Debugger_Resources.Debug_EventDescription_Exception;
+					string innerExceptionStr = "";
+					var loopExp = ex;
+					while (loopExp?.HasData<DbgException>() == true) {//innerException
+						loopExp = loopExp.GetData<DbgException>();
+						innerExceptionStr += $"\n\tInnerException: {GetExceptionName(loopExp)}";
+						if (!string.IsNullOrEmpty(loopExp.Message))
+							innerExceptionStr += $" : {loopExp.Message}";
+					}
+					innerExceptionStr = innerExceptionStr.Trim();
 					exMsg += $" : pid={ex.Process.Id}({GetProcessName(ex.Process)}), {GetExceptionName(ex)}";
 					if (!string.IsNullOrEmpty(ex.Message))
 						exMsg += $" : {ex.Message}";
+					if (!string.IsNullOrEmpty(innerExceptionStr))
+						exMsg += $"\n\t{innerExceptionStr}\n";
 					return exMsg;
 
 				case DbgMessageKind.BoundBreakpoint:

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/Impl/DbgObjectFactoryImpl.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/Impl/DbgObjectFactoryImpl.cs
@@ -96,14 +96,15 @@ namespace dnSpy.Debugger.Impl {
 			return engineThread;
 		}
 
-		public override DbgException CreateException<T>(DbgExceptionId id, DbgExceptionEventFlags flags, string? message, int? hResult, DbgThread? thread, DbgModule? module, DbgEngineMessageFlags messageFlags, T? data, Action<DbgException>? onCreated) where T : class {
+		public override DbgException CreateException<T>(DbgExceptionId id, DbgExceptionEventFlags flags, string? message, int? hResult, DbgThread? thread, DbgModule? module, DbgEngineMessageFlags messageFlags, T? data, Action<DbgException>? onCreated, bool doNotAddExceptionToRuntime) where T : class {
 			if (id.IsDefaultId)
 				throw new ArgumentException();
 			var exception = new DbgExceptionImpl(runtime, id, flags, message, hResult, thread, module);
 			if (data is not null)
 				exception.GetOrCreateData(() => data);
 			onCreated?.Invoke(exception);
-			owner.Dispatcher.BeginInvoke(() => owner.AddException_DbgThread(runtime, exception, messageFlags));
+			if (!doNotAddExceptionToRuntime)
+				owner.Dispatcher.BeginInvoke(() => owner.AddException_DbgThread(runtime, exception, messageFlags));
 			return exception;
 		}
 

--- a/dnSpy/dnSpy.Contracts.Debugger/DbgObject.cs
+++ b/dnSpy/dnSpy.Contracts.Debugger/DbgObject.cs
@@ -81,8 +81,10 @@ namespace dnSpy.Contracts.Debugger {
 				data = dataList is null || dataList.Count == 0 ? Array.Empty<(RuntimeTypeHandle, object)>() : dataList.ToArray();
 				dataList?.Clear();
 			}
-			foreach (var kv in data)
+			foreach (var kv in data) {
+				(kv.data as Exceptions.DbgException)?.Close(dispatcher);
 				(kv.data as IDisposable)?.Dispose();
+			}
 
 #if DEBUG
 			GC.SuppressFinalize(this);
@@ -163,7 +165,7 @@ namespace dnSpy.Contracts.Debugger {
 						return (T)kv.data;
 				}
 				var value = create();
-				Debug.Assert(!(value is DbgObject));
+				Debug.Assert(!(value is DbgObject && value is not Exceptions.DbgException));
 				dataList.Add((type, value));
 				return value;
 			}

--- a/dnSpy/dnSpy.Contracts.Debugger/Engine/DbgObjectFactory.cs
+++ b/dnSpy/dnSpy.Contracts.Debugger/Engine/DbgObjectFactory.cs
@@ -208,8 +208,9 @@ namespace dnSpy.Contracts.Debugger.Engine {
 		/// <param name="messageFlags">Message flags</param>
 		/// <param name="data">Data to add to the <see cref="DbgException"/> or null if nothing gets added</param>
 		/// <param name="onCreated">Called right after creating the exception but before adding it to internal data structures. This can be null.</param>
+		/// <param name="doNotAddExceptionToRuntime">Do not add this exception to the main runtime through the dispatcher</param>
 		/// <returns></returns>
-		public abstract DbgException CreateException<T>(DbgExceptionId id, DbgExceptionEventFlags flags, string? message, int? hResult, DbgThread? thread, DbgModule? module, DbgEngineMessageFlags messageFlags, T? data, Action<DbgException>? onCreated = null) where T : class;
+		public abstract DbgException CreateException<T>(DbgExceptionId id, DbgExceptionEventFlags flags, string? message, int? hResult, DbgThread? thread, DbgModule? module, DbgEngineMessageFlags messageFlags, T? data, Action<DbgException>? onCreated = null, bool doNotAddExceptionToRuntime=false) where T : class;
 
 		/// <summary>
 		/// Value used when the bound breakpoint's address isn't known


### PR DESCRIPTION
Rather than just grabbing the outer exception type and message grab it for inner exceptions as well.

This is a step towards #69 

The overall strategy was:
- Get the same data for inner exceptions we get for the main exception itself (as possible) meaning type of exception and the message (and hResult).
- Refactor some functions to reduce any code duplication in the new code path
- Try to establish the same recursive pattern standard exception objects have with inner exceptions rather than stringifying or converting it at time of DbgException creation

It is mainly just for feedback/POC now as this mixes a whole bunch of approaches to see what is preferred.

- For public methods to add a new parameter that is not required would it be preferred for a new overload method to be created or is modifying the current function to have a new default parameter ok?  The second would be cleaner but means any code that ends up mixed will throw an exception with the newer dll as the old method is gone.  IE a plugin that uses it that hasn't been recompiled. 
- I was not sure the best way to handle `DbgObject` base class.   It didn't look like the data parameter got stuffed anywhere for DbgExceptions so I threw the InnerException data in there using another DbgException object.  We could use another class for InnerException data but it seemed logical to tie to another DbgException so we have the additional methods and such available to us.   The problem is DbgException inherits from DbgObject which makes sure data added is not classed from DbgObject.  Could wrap the DbgException in an outer class (ie DbgInnerException which has a single property DbgException exception) that would bypass that check, but then the Close() function would be tricky. Even if DbgInnerException implemented iDisposable it would not be able to get the DbgDispatcher.     Instead I hardcoded an exception into DbgObject for DbgException and took it a step further and made sure when DbgObject Close is called, it is also called on DbgException data.  This could be more generalized to allow sub DbgObjects and similarly call Close on them, but I don't really  have any core understanding of dnSpy.   Why that assert is there, or what evil I may be unlocking.  Given the limited InnerException data we could just switch to a new class with two strings and an int (hResult) and not worry about the DbgObject Close or check.
-  Actually getting the InnerException object was abit trickier than expected.  GetField does not work as it checks to make sure the reflected type is the same as the declared type and does not return it if private otherwise.  To work around this I could call GetFields() to get all of them and then filter by name, but that seems like a waste.  Instead I figured add an option for GetField.   There are two ways I saw to do this.  One is how I did, add another parameter allowTypeVarianceOnPrivateFields the other was to modifying the  DmdBindingFlags and add an option like AllowTypeVarianceOnPrivateField.  This being a mirror of the true BindingFlags class though seemed like a poor way to go too.
- As it is POC propagating AllowTypeVarianceOnPrivate* is not on getmethod, etc 100% yet despite them having similar checks.

Some potential negatives of the current code:

- No recursion protection, I don't think a loop is likely as InnerException is RO but im sure possible with a new _InnerException or similar
- It gets the entire InnerException tree for every exception even if we don't "care" about them (although generally still console logged). We could try defer processing InnerException but may need to keep more data/be careful about making sure everything gets released after.
- Not sure if it is worth trying to do something more like capture the stack trace or doing a ToString on the exception itself through eval.  A break on an exception already lets you see the $exception in locals, calling ToString clearly could have potential other side effects for not a huge amount of value.

Assuming this is not the completely wrong way to go about this let me know some guidance on how you would like things handled and I will clean it up.

An exception thrown of:
`throw new ArgumentNullException("Yes it was", new FileNotFoundException("Where is it Bobbbbbbbbb", "c:\\temp\\test.txt", new Exception("It fell off")));`
returns in the main window showing:
![image](https://user-images.githubusercontent.com/1643324/179901166-68822c9a-f77c-4e7c-a11c-cbe68ec96357.png)

I would take it a step further and likely add to the console log and messagebox as well.