### PR TITLE
BAML→XAML decompile: fix nested Type names & MarkupExtension handling

### DIFF
--- a/Extensions/dnSpy.BamlDecompiler/Rewrite/MarkupExtensionRewritePass.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Rewrite/MarkupExtensionRewritePass.cs
@@ -54,7 +54,7 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 			return doWork;
 		}
 
-		static bool NonInlineAttibute(XAttribute attr) => attr.Name.Namespace == XamlContext.KnownNamespace_Xaml;
+		static bool IsXamlNsAttr(XAttribute attr) => attr.Name.Namespace == XamlContext.KnownNamespace_Xaml;
 
 		bool RewriteElement(XamlContext ctx, XElement parent, XElement elem) {
 			var type = parent.Annotation<XamlType>();
@@ -68,7 +68,7 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 					return false;
 			}
 
-			if (elem.Elements().Count() != 1 || elem.Attributes().Any(NonInlineAttibute))
+			if (elem.Elements().Count() != 1 || elem.Attributes().Any(IsXamlNsAttr))
 				return false;
 
 			var value = elem.Elements().Single();
@@ -121,7 +121,7 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 			         ctxElement.Name != ctor)
 				return false;
 
-			if (ctxElement.Attributes().Any(NonInlineAttibute))
+			if (ctxElement.Attributes().Any(IsXamlNsAttr))
 				return false;
 
 			foreach (var child in ctxElement.Elements()) {
@@ -160,7 +160,7 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 			var ext = new XamlExtension(type);
 
 			foreach (var attr in ctxElement.Attributes()) {
-				Debug2.Assert(!NonInlineAttibute(attr));
+				Debug2.Assert(!IsXamlNsAttr(attr));
 				ext.NamedArguments[attr.Name.LocalName] = attr.Value;
 			}
 
@@ -182,7 +182,7 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 
 				var property = elem.Annotation<XamlProperty>();
 				if (property is null || elem.Nodes().Count() != 1 ||
-				    elem.Attributes().Any(NonInlineAttibute))
+				    elem.Attributes().Any(IsXamlNsAttr))
 					return null;
 
 				var name = property.PropertyName;

--- a/Extensions/dnSpy.BamlDecompiler/Rewrite/MarkupExtensionRewritePass.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Rewrite/MarkupExtensionRewritePass.cs
@@ -21,6 +21,7 @@
 */
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Xml.Linq;
 using dnlib.DotNet;
@@ -159,7 +160,7 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 			var ext = new XamlExtension(type);
 
 			foreach (var attr in ctxElement.Attributes()) {
-				Debug.Assert(!NonInlineAttibute(attr));
+				Debug2.Assert(!NonInlineAttibute(attr));
 				ext.NamedArguments[attr.Name.LocalName] = attr.Value;
 			}
 

--- a/Extensions/dnSpy.BamlDecompiler/Xaml/XamlUtils.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Xaml/XamlUtils.cs
@@ -48,7 +48,7 @@ namespace dnSpy.BamlDecompiler.Xaml {
 					sb.Append(':');
 				}
 			}
-			sb.Append(name.LocalName);
+			sb.Append(name.LocalName.Replace("_x002B_", "+"));
 			return sb.ToString();
 		}
 

--- a/Extensions/dnSpy.BamlDecompiler/Xaml/XamlUtils.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Xaml/XamlUtils.cs
@@ -48,7 +48,7 @@ namespace dnSpy.BamlDecompiler.Xaml {
 					sb.Append(':');
 				}
 			}
-			sb.Append(name.LocalName.Replace("_x002B_", "+"));
+			sb.Append(name.LocalName);
 			return sb.ToString();
 		}
 

--- a/Extensions/dnSpy.BamlDecompiler/XamlContext.cs
+++ b/Extensions/dnSpy.BamlDecompiler/XamlContext.cs
@@ -91,8 +91,8 @@ namespace dnSpy.BamlDecompiler {
 
 		static string NestedReflectionName(ITypeDefOrRef type, out string clrNs) {
 			var name = type.ReflectionFullName;
-			while (type.DeclaringType is ITypeDefOrRef t2)
-				type = t2;
+			while (type.DeclaringType is ITypeDefOrRef declaringType)
+				type = declaringType;
 			clrNs = type.ReflectionNamespace;
 			name = name.Substring(clrNs.Length + 1);
 			return name;

--- a/Extensions/dnSpy.BamlDecompiler/XamlContext.cs
+++ b/Extensions/dnSpy.BamlDecompiler/XamlContext.cs
@@ -89,8 +89,7 @@ namespace dnSpy.BamlDecompiler {
 			}
 		}
 
-		static string NestedReflectionName(ITypeDefOrRef type, out string clrNs)
-		{
+		static string NestedReflectionName(ITypeDefOrRef type, out string clrNs) {
 			var name = type.ReflectionFullName;
 			while (type.DeclaringType is ITypeDefOrRef t2)
 				type = t2;


### PR DESCRIPTION
**1.) BAML examples containing nested type names in MarkupExtensions,now much improved:**

      System.Activities.Presentation.View.TypeBrowser
      System.Activities.Core.Presentation.FlowchartDesigner
      System.Activities.Core.Presentation.FlowchartDesigner
      System.Activities.Presentation.View.VBIdentifierDesigner

Use `+` when decompiling from BAML to XAML when some MarkupExtensions contain nested Type names e.g.
`"{x:Static sad:WorkflowDesignerIcons+DesignerItems.WarningValidation}"`. The plus symbol is what the XAML compiler will accept, so I matched the behavior somewhat, but unfortunately, 'plus' is not a legal character in an XML name, when bare (unquoted) as I have currently done...

**BEFORE...**
The use of several nested types causes rampant corruption in `System.Activities.Presentation.View.TypeBrowser`:

```XAML
<HierarchicalDataTemplate
	x:Key="{DataTemplateKey {x:Type global:AssemblyNode}}"
	x:Uid="HierarchicalDataTemplate_1" xmlns:global="clr-namespace:"
	DataType="{x:Type global:AssemblyNode}"
	ItemsSource="{Binding Path=Namespaces}">
    <!-- ... -->
</HierarchicalDataTemplate>
```

**AFTER...**
There are still serious problems with nested types support in XAML, but I was able to fix the major problems:

```XAML
<HierarchicalDataTemplate
	x:Key="{DataTemplateKey {x:Type swdv:TypeBrowser+AssemblyNode}}"
	x:Uid="HierarchicalDataTemplate_1"
	DataType="{x:Type swdv:TypeBrowser+AssemblyNode}"
	ItemsSource="{Binding Path=Namespaces}">
    <!-- ... -->
</HierarchicalDataTemplate>
```

**2.) Fix BAML→XAML corruption due to incorrect MarkupExtension re-expansion** 

BEFORE...   (ToolboxDefaultTemplate.baml  in   System.Activities.Presentation.g.resources...)

```xaml
<ResourceDictionary x:Uid="ResourceDictionary_1"
    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
	xmlns:swdv="clr-namespace:System.Activities.Presentation.View"
	xmlns:swd="clr-namespace:System.Activities.Presentation"
	xmlns:swdt="clr-namespace:System.Activities.Presentation.Toolbox">

	<ControlTemplate
		x:Key="ToolboxDefaultTemplate"
		x:Uid="ControlTemplate_1"
		TargetType="{x:Type swdt:ToolboxControl}"
		Resources="{swd:CachedResourceDictionary Uid=swd:CachedResourceDictionaryExtension_1, Source=pack://application:,,,/System.Activities.Presentation;component/Themes/Generic.xaml}">

		<Grid> <!-- ... --> </Grid>
	</ControlTemplate>
</ResourceDictionary>
```

Notice above that the "Resources" property accepting a MarkupExtension was attempted to be inlined, but this decision was faulty and led to the total corruption as shown. There were about three bugs affecting the decision conditions of whether it can be done. Most seriously, you cannout promote a MarkupExtension to inline if there is a XAML directive (i.e. `x:`) attribute on the instance itself (and recursively inward), because directives are not actual attributes and would not properly understood by the MarkupExtension syntax processing. The exisiting code seemed to be aware of this idea, but it was implemented incorrectly, and also had a logic-polarity bug whereby it was ignoring most of its own efforts.

AFTER...
```xaml
<ResourceDictionary x:Uid="ResourceDictionary_1"
	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
	xmlns:swdv="clr-namespace:System.Activities.Presentation.View"
	xmlns:swd="clr-namespace:System.Activities.Presentation"
	xmlns:swdt="clr-namespace:System.Activities.Presentation.Toolbox">
	
	<ControlTemplate
		x:Key="ToolboxDefaultTemplate"
		x:Uid="ControlTemplate_1"
		TargetType="{x:Type swdt:ToolboxControl}">
		
		<FrameworkTemplate.Resources>
			<swd:CachedResourceDictionaryExtension x:Uid="swd:CachedResourceDictionaryExtension_1" Source="pack://application:,,,/System.Activities.Presentation;component/Themes/Generic.xaml" />
		</FrameworkTemplate.Resources>
		
		<Grid> <!-- ... --> </Grid>
	</ControlTemplate>
</ResourceDictionary>
```