### PR TITLE
prevent `AggregateException` when connecting to unity process

### DIFF
--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Impl/DbgEngineImpl.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Impl/DbgEngineImpl.cs
@@ -424,17 +424,14 @@ namespace dnSpy.Debugger.DotNet.Mono.Impl {
 						var cts = new CancellationTokenSource(connectionTimeout - elapsedTime);
 						var asyncConn = VirtualMachineManager.ConnectAsync(endPoint, null, cts.Token);
 						if (!asyncConn.Wait(connectionTimeout - elapsedTime))
-							throw new CouldNotConnectException(
-								GetCouldNotConnectErrorMessage(connectionAddress, connectionPort, filename));
+							throw new CouldNotConnectException(GetCouldNotConnectErrorMessage(connectionAddress, connectionPort, filename));
 						vm = asyncConn.Result;
 						break;
 					}
 					catch (SocketException sex) when (sex.SocketErrorCode == SocketError.ConnectionRefused) {
 						// Retry it in case it takes a while for mono.exe to initialize or if it hasn't started yet
 					}
-					catch (AggregateException aex) when (aex.InnerExceptions.All(ex => ex is SocketException {
-						                                     SocketErrorCode: SocketError.ConnectionRefused
-					                                     })) {
+					catch (AggregateException aex) when (aex.InnerExceptions.Count == 1 && aex.InnerExceptions[0] is SocketException {SocketErrorCode: SocketError.ConnectionRefused}) {
 						// Retry it in case it takes a while
 					}
 					Thread.Sleep(100);


### PR DESCRIPTION
Link to issue(s) this pull request covers: #189 

### Problem
This should fix #189 

### Solution
Catch `AggregateException`, too.

![dnError1](https://user-images.githubusercontent.com/4312781/234576971-e1e31a55-06d7-4041-9fb3-a2d877921524.png)

