### PR TITLE
Improve decompilation of XAML markup extensions

### DIFF
--- a/Extensions/dnSpy.BamlDecompiler/Annotations.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Annotations.cs
@@ -1,3 +1,4 @@
+using System.Xml.Linq;
 using dnSpy.BamlDecompiler.Xaml;
 
 namespace dnSpy.BamlDecompiler {
@@ -11,5 +12,16 @@ namespace dnSpy.BamlDecompiler {
 		public XamlType Type { get; }
 
 		public TargetTypeAnnotation(XamlType type) => Type = type;
+	}
+
+	sealed class IsMemberNameAnnotation {
+		public static readonly IsMemberNameAnnotation Instance = new IsMemberNameAnnotation();
+	}
+
+	static class XNodeAnnotationExtensions {
+		public static T WithAnnotation<T>(this T node, object annotation) where T : XNode {
+			node.AddAnnotation(annotation);
+			return node;
+		}
 	}
 }

--- a/Extensions/dnSpy.BamlDecompiler/Baml/BamlUtils.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Baml/BamlUtils.cs
@@ -1,0 +1,20 @@
+namespace dnSpy.BamlDecompiler.Baml {
+	static class BamlUtils {
+		internal static short GetKnownResourceIdFromBamlId(ushort bamlId, out bool isKey) {
+			short resourceId = unchecked((short)-bamlId);
+			isKey = true;
+			if (resourceId > 232 && resourceId < 464) {
+				resourceId -= 232;
+				isKey = false;
+			}
+			else if (resourceId > 464 && resourceId < 467) {
+				resourceId -= 231;
+			}
+			else if (resourceId > 467 && resourceId < 470) {
+				resourceId -= 234;
+				isKey = false;
+			}
+			return resourceId;
+		}
+	}
+}

--- a/Extensions/dnSpy.BamlDecompiler/BamlDisassembler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/BamlDisassembler.cs
@@ -232,20 +232,9 @@ namespace dnSpy.BamlDecompiler {
 		object GetResourceReferenceObject(BamlContext ctx, ushort id) {
 			if (resourceReferences.TryGetValue(id, out var reference))
 				return reference;
-			bool isKey = true;
-			short bamlId = unchecked((short)-id);
-			if (bamlId > 232 && bamlId < 464) {
-				bamlId -= 232;
-				isKey = false;
-			}
-			else if (bamlId > 464 && bamlId < 467) {
-				bamlId -= 231;
-			}
-			else if (bamlId > 467 && bamlId < 470) {
-				bamlId -= 234;
-				isKey = false;
-			}
-			var res = ctx.KnownThings.Resources(bamlId);
+
+			var resourceId = BamlUtils.GetKnownResourceIdFromBamlId(id, out bool isKey);
+			var res = ctx.KnownThings.Resources(resourceId);
 			return resourceReferences[id] = isKey
 					? BamlResourceReference.CreateKey(res.TypeName, res.KeyName)
 					: BamlResourceReference.CreateProperty(res.TypeName, res.PropertyName);

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/ConstructorParameterTypeHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/ConstructorParameterTypeHandler.cs
@@ -39,7 +39,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			parent.Xaml.Element.Add(elem);
 
 			var type = ctx.ResolveType(record.TypeId);
-			var typeName = ctx.ToString(parent.Xaml, type);
+			var typeName = type.ToMarkupExtensionName(ctx, parent.Xaml);
 			elem.Add(new XElement(ctx.GetPseudoName("Ctor"), typeName));
 
 			return bamlElem;

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/DefAttributeKeyTypeHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/DefAttributeKeyTypeHandler.cs
@@ -36,7 +36,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 		public BamlElement TranslateDefer(XamlContext ctx, BamlNode node, BamlElement parent) {
 			var record = (DefAttributeKeyTypeRecord)((BamlRecordNode)node).Record;
 			var type = ctx.ResolveType(record.TypeId);
-			var typeName = ctx.ToString(parent.Xaml, type);
+			var typeName = type.ToMarkupExtensionName(ctx, parent.Xaml);
 			var key = (XamlResourceKey)node.Annotation;
 
 			var bamlElem = new BamlElement(node);

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/DefAttributeKeyTypeHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/DefAttributeKeyTypeHandler.cs
@@ -45,7 +45,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 
 			var typeElem = new XElement(ctx.GetKnownNamespace("TypeExtension", XamlContext.KnownNamespace_Xaml, parent.Xaml));
 			typeElem.AddAnnotation(ctx.ResolveType(0xfd4d)); // Known type - TypeExtension
-			typeElem.Add(new XElement(ctx.GetPseudoName("Ctor"), typeName));
+			typeElem.Add(new XElement(ctx.GetPseudoName("Ctor"), new XText(typeName).WithAnnotation(IsMemberNameAnnotation.Instance)));
 			bamlElem.Xaml.Element.Add(typeElem);
 
 			key.KeyElement = bamlElem;

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/OptimizedStaticResourceHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/OptimizedStaticResourceHandler.cs
@@ -52,20 +52,8 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			else if (record.IsValueStaticExtension) {
 				string attrName;
 				if (record.ValueId > 0x7fff) {
-					bool isKey = true;
-					short bamlId = unchecked((short)-record.ValueId);
-					if (bamlId > 232 && bamlId < 464) {
-						bamlId -= 232;
-						isKey = false;
-					}
-					else if (bamlId > 464 && bamlId < 467) {
-						bamlId -= 231;
-					}
-					else if (bamlId > 467 && bamlId < 470) {
-						bamlId -= 234;
-						isKey = false;
-					}
-					var res = ctx.Baml.KnownThings.Resources(bamlId);
+					var resId = BamlUtils.GetKnownResourceIdFromBamlId(record.ValueId, out bool isKey);
+					var res = ctx.Baml.KnownThings.Resources(resId);
 					string name;
 					if (isKey)
 						name = res.TypeName + "." + res.KeyName;

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/OptimizedStaticResourceHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/OptimizedStaticResourceHandler.cs
@@ -42,10 +42,11 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			object key;
 			if (record.IsValueTypeExtension) {
 				var value = ctx.ResolveType(record.ValueId);
+				string typeName = value.ToMarkupExtensionName(ctx, parent.Xaml);
 
 				var typeElem = new XElement(ctx.GetKnownNamespace("TypeExtension", XamlContext.KnownNamespace_Xaml, parent.Xaml));
 				typeElem.AddAnnotation(ctx.ResolveType(0xfd4d)); // Known type - TypeExtension
-				typeElem.Add(new XElement(ctx.GetPseudoName("Ctor"), ctx.ToString(parent.Xaml, value)));
+				typeElem.Add(new XElement(ctx.GetPseudoName("Ctor"), typeName));
 				key = typeElem;
 			}
 			else if (record.IsValueStaticExtension) {
@@ -77,9 +78,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 					var value = ctx.ResolveProperty(record.ValueId);
 
 					value.DeclaringType.ResolveNamespace(parent.Xaml, ctx);
-					var xName = value.ToXName(ctx, parent.Xaml);
-
-					attrName = ctx.ToString(parent.Xaml, xName);
+					attrName = value.ToMarkupExtensionName(ctx, parent.Xaml);
 				}
 
 				var staticElem = new XElement(ctx.GetKnownNamespace("StaticExtension", XamlContext.KnownNamespace_Xaml, parent.Xaml));

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/OptimizedStaticResourceHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/OptimizedStaticResourceHandler.cs
@@ -46,7 +46,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 
 				var typeElem = new XElement(ctx.GetKnownNamespace("TypeExtension", XamlContext.KnownNamespace_Xaml, parent.Xaml));
 				typeElem.AddAnnotation(ctx.ResolveType(0xfd4d)); // Known type - TypeExtension
-				typeElem.Add(new XElement(ctx.GetPseudoName("Ctor"), typeName));
+				typeElem.Add(new XElement(ctx.GetPseudoName("Ctor"), new XText(typeName).WithAnnotation(IsMemberNameAnnotation.Instance)));
 				key = typeElem;
 			}
 			else if (record.IsValueStaticExtension) {
@@ -71,7 +71,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 
 				var staticElem = new XElement(ctx.GetKnownNamespace("StaticExtension", XamlContext.KnownNamespace_Xaml, parent.Xaml));
 				staticElem.AddAnnotation(ctx.ResolveType(0xfda6)); // Known type - StaticExtension
-				staticElem.Add(new XElement(ctx.GetPseudoName("Ctor"), attrName));
+				staticElem.Add(new XElement(ctx.GetPseudoName("Ctor"), new XText(attrName).WithAnnotation(IsMemberNameAnnotation.Instance)));
 				key = staticElem;
 			}
 			else

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyCustomHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyCustomHandler.cs
@@ -47,12 +47,12 @@ namespace dnSpy.BamlDecompiler.Handlers {
 					case KnownTypes.DependencyPropertyConverter: {
 						if (value.Length == 2 || !isValueTypeId) {
 							var property = ctx.ResolveProperty(reader.ReadUInt16());
-							return ctx.ToString(elem, property.ToXName(ctx, elem, NeedsFullName(property, elem)));
+							return property.ToMarkupExtensionName(ctx, elem, NeedsFullName(property, elem));
 						}
 						else {
 							var type = ctx.ResolveType(reader.ReadUInt16());
 							var name = reader.ReadString();
-							var typeName = ctx.ToString(elem, type);
+							var typeName = type.ToMarkupExtensionName(ctx, elem);
 							return typeName + "." + name;
 						}
 					}

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyTypeReferenceHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyTypeReferenceHandler.cs
@@ -32,7 +32,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			var record = (PropertyTypeReferenceRecord)((BamlRecordNode)node).Record;
 			var attr = ctx.ResolveProperty(record.AttributeId);
 			var type = ctx.ResolveType(record.TypeId);
-			var typeName = ctx.ToString(parent.Xaml, type);
+			var typeName = type.ToMarkupExtensionName(ctx, parent.Xaml);
 
 			var elem = new BamlElement(node);
 

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyTypeReferenceHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyTypeReferenceHandler.cs
@@ -47,7 +47,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 
 			var typeElem = new XElement(ctx.GetKnownNamespace("TypeExtension", XamlContext.KnownNamespace_Xaml, parent.Xaml));
 			typeElem.AddAnnotation(ctx.ResolveType(0xfd4d)); // Known type - TypeExtension
-			typeElem.Add(new XElement(ctx.GetPseudoName("Ctor"), typeName));
+			typeElem.Add(new XElement(ctx.GetPseudoName("Ctor"), new XText(typeName).WithAnnotation(IsMemberNameAnnotation.Instance)));
 			elem.Xaml.Element.Add(typeElem);
 
 			elemAttr.DeclaringType.ResolveNamespace(elem.Xaml, ctx);

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyWithExtensionHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyWithExtensionHandler.cs
@@ -58,20 +58,8 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			else if (valStaticExt || extTypeId == (short)KnownTypes.StaticExtension) {
 				string attrName;
 				if (record.ValueId > 0x7fff) {
-					bool isKey = true;
-					short bamlId = unchecked((short)-record.ValueId);
-					if (bamlId > 232 && bamlId < 464) {
-						bamlId -= 232;
-						isKey = false;
-					}
-					else if (bamlId > 464 && bamlId < 467) {
-						bamlId -= 231;
-					}
-					else if (bamlId > 467 && bamlId < 470) {
-						bamlId -= 234;
-						isKey = false;
-					}
-					var res = ctx.Baml.KnownThings.Resources(bamlId);
+					var resId = BamlUtils.GetKnownResourceIdFromBamlId(record.ValueId, out bool isKey);
+					var res = ctx.Baml.KnownThings.Resources(resId);
 					string name;
 					if (isKey)
 						name = res.TypeName + "." + res.KeyName;

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyWithExtensionHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyWithExtensionHandler.cs
@@ -43,7 +43,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			if (valTypeExt || extTypeId == (short)KnownTypes.TypeExtension) {
 				var value = ctx.ResolveType(record.ValueId);
 
-				object[] initializer = { value.ToMarkupExtensionName(ctx, parent.Xaml) };
+				object[] initializer = { new XamlMemberName(value.ToMarkupExtensionName(ctx, parent.Xaml)) };
 				if (valTypeExt)
 					initializer = new object[] { new XamlExtension(ctx.ResolveType(0xfd4d)) { Initializer = initializer } }; // Known type - TypeExtension
 
@@ -53,7 +53,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 				var value = ctx.ResolveProperty(record.ValueId);
 
 				value.DeclaringType.ResolveNamespace(parent.Xaml, ctx);
-				ext.Initializer = new object[] { value.ToMarkupExtensionName(ctx, parent.Xaml) };
+				ext.Initializer = new object[] { new XamlMemberName(value.ToMarkupExtensionName(ctx, parent.Xaml)) };
 			}
 			else if (valStaticExt || extTypeId == (short)KnownTypes.StaticExtension) {
 				string attrName;
@@ -75,7 +75,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 					attrName = value.ToMarkupExtensionName(ctx, parent.Xaml);
 				}
 
-				object[] initializer = { attrName };
+				object[] initializer = { new XamlMemberName(attrName) };
 				if (valStaticExt)
 					initializer = new object[] { new XamlExtension(ctx.ResolveType(0xfda6)) { Initializer = initializer } }; // Known type - StaticExtension
 

--- a/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyWithExtensionHandler.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Handlers/Records/PropertyWithExtensionHandler.cs
@@ -43,7 +43,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 			if (valTypeExt || extTypeId == (short)KnownTypes.TypeExtension) {
 				var value = ctx.ResolveType(record.ValueId);
 
-				object[] initializer = { ctx.ToString(parent.Xaml, value) };
+				object[] initializer = { value.ToMarkupExtensionName(ctx, parent.Xaml) };
 				if (valTypeExt)
 					initializer = new object[] { new XamlExtension(ctx.ResolveType(0xfd4d)) { Initializer = initializer } }; // Known type - TypeExtension
 
@@ -53,9 +53,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 				var value = ctx.ResolveProperty(record.ValueId);
 
 				value.DeclaringType.ResolveNamespace(parent.Xaml, ctx);
-				var xName = value.ToXName(ctx, parent.Xaml);
-
-				ext.Initializer = new object[] { ctx.ToString(parent.Xaml, xName) };
+				ext.Initializer = new object[] { value.ToMarkupExtensionName(ctx, parent.Xaml) };
 			}
 			else if (valStaticExt || extTypeId == (short)KnownTypes.StaticExtension) {
 				string attrName;
@@ -86,9 +84,7 @@ namespace dnSpy.BamlDecompiler.Handlers {
 					var value = ctx.ResolveProperty(record.ValueId);
 
 					value.DeclaringType.ResolveNamespace(parent.Xaml, ctx);
-					var xName = value.ToXName(ctx, parent.Xaml);
-
-					attrName = ctx.ToString(parent.Xaml, xName);
+					attrName = value.ToMarkupExtensionName(ctx, parent.Xaml);
 				}
 
 				object[] initializer = { attrName };

--- a/Extensions/dnSpy.BamlDecompiler/Rewrite/MarkupExtensionRewritePass.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Rewrite/MarkupExtensionRewritePass.cs
@@ -132,8 +132,11 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 		}
 
 		object InlineObject(XamlContext ctx, XNode obj) {
-			if (obj is XText text)
+			if (obj is XText text) {
+				if (text.Annotation<IsMemberNameAnnotation>() is not null)
+					return new XamlMemberName(text.Value);
 				return text.Value;
+			}
 			if (obj is XElement element)
 				return InlineExtension(ctx, element);
 			return null;

--- a/Extensions/dnSpy.BamlDecompiler/Rewrite/XClassRewritePass.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Rewrite/XClassRewritePass.cs
@@ -43,7 +43,8 @@ namespace dnSpy.BamlDecompiler.Rewrite {
 				return;
 
 			var newType = typeDef.BaseType;
-			var xamlType = new XamlType(newType.DefinitionAssembly, newType.ReflectionNamespace, newType.Name);
+			var name = XamlTypeName.From(newType, out string clrNs);
+			var xamlType = new XamlType(newType.DefinitionAssembly, clrNs, name);
 			xamlType.ResolveNamespace(elem, ctx);
 
 			elem.Name = xamlType.ToXName(ctx);

--- a/Extensions/dnSpy.BamlDecompiler/Xaml/XamlExtension.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Xaml/XamlExtension.cs
@@ -39,6 +39,10 @@ namespace dnSpy.BamlDecompiler.Xaml {
 		static void WriteObject(StringBuilder sb, XamlContext ctx, XElement ctxElement, object value) {
 			if (value is XamlExtension extension)
 				sb.Append(extension.ToString(ctx, ctxElement));
+			else if (value is XamlMemberName memberName)
+				sb.Append(memberName.MemberName);
+			else if (value is string str)
+				sb.Append(EscapeOrEncapsulateInQuotes(str));
 			else
 				sb.Append(value);
 		}
@@ -80,5 +84,40 @@ namespace dnSpy.BamlDecompiler.Xaml {
 			sb.Append('}');
 			return sb.ToString();
 		}
+
+		static string EscapeOrEncapsulateInQuotes(string value) {
+			var escaped = EscapeAttributeValue(value);
+			for (int i = 0; i < escaped.Length; i++) {
+				char c = escaped[i];
+				if (char.IsWhiteSpace(c) || c == '\'' || c == ',' || c == '=')
+					return $"'{value.Replace("'", "\\'")}'";
+			}
+			return escaped;
+		}
+
+		static string EscapeAttributeValue(string value) {
+			if (string.IsNullOrEmpty(value))
+				return string.Empty;
+			StringBuilder stringBuilder = null;
+			for (int i = 0; i < value.Length; i++) {
+				char c = value[i];
+				if (c == '"' || c == '<' || c == '>' || c == '&') {
+					stringBuilder ??= new StringBuilder(value.Length + 8).Append(value, 0, i);
+					stringBuilder.Append(EscapeChar(c));
+				}
+				else
+					stringBuilder?.Append(c);
+			}
+			return stringBuilder is not null ? stringBuilder.ToString() : value;
+		}
+
+		static string EscapeChar(char c) => c switch {
+			'"' => "&quot;",
+			'&' => "&amp;",
+			'\'' => "&apos;",
+			'<' => "&lt;",
+			'>' => "&gt;",
+			_ => null
+		};
 	}
 }

--- a/Extensions/dnSpy.BamlDecompiler/Xaml/XamlExtension.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Xaml/XamlExtension.cs
@@ -47,7 +47,7 @@ namespace dnSpy.BamlDecompiler.Xaml {
 			var sb = new StringBuilder();
 			sb.Append('{');
 
-			var typeName = ctx.ToString(ctxElement, ExtensionType);
+			var typeName = ExtensionType.ToMarkupExtensionName(ctx, ctxElement);
 			if (typeName.EndsWith("Extension", StringComparison.Ordinal))
 				sb.Append(typeName.Substring(0, typeName.Length - 9));
 			else

--- a/Extensions/dnSpy.BamlDecompiler/Xaml/XamlMemberName.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Xaml/XamlMemberName.cs
@@ -1,5 +1,5 @@
-/*
-	Copyright (c) 2015 Ki
+﻿/*
+	Copyright (c) 2023 ElektroKill
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
@@ -20,29 +20,12 @@
 	THE SOFTWARE.
 */
 
-using System.Xml.Linq;
-using dnSpy.BamlDecompiler.Baml;
-using dnSpy.BamlDecompiler.Xaml;
+namespace dnSpy.BamlDecompiler.Xaml {
+	public sealed class XamlMemberName {
+		public string MemberName { get; }
 
-namespace dnSpy.BamlDecompiler.Handlers {
-	sealed class ConstructorParameterTypeHandler : IHandler {
-		public BamlRecordType Type => BamlRecordType.ConstructorParameterType;
+		public XamlMemberName(string memberName) => MemberName = memberName;
 
-		public BamlElement Translate(XamlContext ctx, BamlNode node, BamlElement parent) {
-			var record = (ConstructorParameterTypeRecord)((BamlRecordNode)node).Record;
-
-			var elem = new XElement(ctx.GetKnownNamespace("TypeExtension", XamlContext.KnownNamespace_Xaml, parent.Xaml));
-			elem.AddAnnotation(ctx.ResolveType(0xfd4d)); // Known type - TypeExtension
-
-			var bamlElem = new BamlElement(node);
-			bamlElem.Xaml = elem;
-			parent.Xaml.Element.Add(elem);
-
-			var type = ctx.ResolveType(record.TypeId);
-			var typeName = type.ToMarkupExtensionName(ctx, parent.Xaml);
-			elem.Add(new XElement(ctx.GetPseudoName("Ctor"), new XText(typeName).WithAnnotation(IsMemberNameAnnotation.Instance)));
-
-			return bamlElem;
-		}
+		public override string ToString() => MemberName;
 	}
 }

--- a/Extensions/dnSpy.BamlDecompiler/Xaml/XamlProperty.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Xaml/XamlProperty.cs
@@ -24,6 +24,7 @@ using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using dnlib.DotNet;
+using dnSpy.Contracts.Decompiler;
 
 namespace dnSpy.BamlDecompiler.Xaml {
 	sealed class XamlProperty {
@@ -31,6 +32,8 @@ namespace dnSpy.BamlDecompiler.Xaml {
 		public string PropertyName { get; }
 
 		public IMemberDef ResolvedMember { get; set; }
+
+		public ITypeDefOrRef ResolvedMemberDeclaringType { get; set; }
 
 		public XamlProperty(XamlType type, string name) {
 			DeclaringType = type;
@@ -41,38 +44,89 @@ namespace dnSpy.BamlDecompiler.Xaml {
 			if (ResolvedMember is not null)
 				return;
 
-			var typeDef = DeclaringType.ResolvedType.ResolveTypeDef();
-			if (typeDef is null)
-				return;
-
-			ResolvedMember = typeDef.FindPropertyCheckBaseType(PropertyName);
+			(ResolvedMember, ResolvedMemberDeclaringType) = FindProperty(DeclaringType.ResolvedType, PropertyName);
 			if (ResolvedMember is not null)
 				return;
 
-			ResolvedMember = typeDef.FindFieldCheckBaseType(PropertyName + "Property");
+			(ResolvedMember, ResolvedMemberDeclaringType) = FindField(DeclaringType.ResolvedType, PropertyName + "Property");
 			if (ResolvedMember is not null)
 				return;
 
-			ResolvedMember = typeDef.FindEventCheckBaseType(PropertyName);
+			(ResolvedMember, ResolvedMemberDeclaringType) = FindEvent(DeclaringType.ResolvedType, PropertyName);
 			if (ResolvedMember is not null)
 				return;
 
-			ResolvedMember = typeDef.FindFieldCheckBaseType(PropertyName + "Event");
+			(ResolvedMember, ResolvedMemberDeclaringType) = FindField(DeclaringType.ResolvedType, PropertyName + "Event");
+		}
+
+		static (PropertyDef, ITypeDefOrRef) FindProperty(ITypeDefOrRef declType, string name) {
+			while (declType is not null) {
+				var td = declType.ResolveTypeDef();
+				if (td is null)
+					break;
+
+				var pd = td.FindProperty(name);
+				if (pd is not null)
+					return (pd, declType);
+
+				declType = GetInstantiatedBaseType(declType);
+			}
+
+			return default;
+		}
+
+		static (EventDef, ITypeDefOrRef) FindEvent(ITypeDefOrRef declType, string name) {
+			while (declType is not null) {
+				var td = declType.ResolveTypeDef();
+				if (td is null)
+					break;
+
+				var ed = td.FindEvent(name);
+				if (ed is not null)
+					return (ed, declType);
+
+				declType = GetInstantiatedBaseType(declType);
+			}
+
+			return default;
+		}
+
+		static (FieldDef, ITypeDefOrRef) FindField(ITypeDefOrRef declType, string name) {
+			while (declType is not null) {
+				var td = declType.ResolveTypeDef();
+				if (td is null)
+					break;
+
+				var fd = td.FindField(name);
+				if (fd is not null)
+					return (fd, declType);
+
+				declType = GetInstantiatedBaseType(declType);
+			}
+
+			return default;
 		}
 
 		public bool IsAttachedTo(XamlType type) {
 			if (type is null || ResolvedMember is null || type.ResolvedType is null)
 				return true;
 
-			var declType = ResolvedMember.DeclaringType;
+			var declType = ResolvedMemberDeclaringType;
 			var t = type.ResolvedType;
 			var comparer = new SigComparer();
 			do {
 				if (comparer.Equals(t, declType))
 					return false;
-				t = t.GetBaseType();
+				t = GetInstantiatedBaseType(t);
 			} while (t is not null);
 			return true;
+		}
+
+		static ITypeDefOrRef GetInstantiatedBaseType(ITypeDefOrRef type) {
+			var baseType = type.GetBaseType();
+			if (type is TypeSpec typeSpec && typeSpec.TypeSig is GenericInstSig genericInstSig && baseType is TypeSpec baseTypeSpec)
+				baseType = GenericArgumentResolver.Resolve(baseTypeSpec.TypeSig, genericInstSig.GenericArguments, null).ToTypeDefOrRef();
+			return baseType;
 		}
 
 		public XName ToXName(XamlContext ctx, XElement parent, bool isFullName = true) {

--- a/Extensions/dnSpy.BamlDecompiler/Xaml/XamlProperty.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Xaml/XamlProperty.cs
@@ -20,6 +20,7 @@
 	THE SOFTWARE.
 */
 
+using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using dnlib.DotNet;
@@ -85,6 +86,25 @@ namespace dnSpy.BamlDecompiler.Xaml {
 					name = typeName.Namespace + name.LocalName;
 			}
 			return name;
+		}
+
+		public string ToMarkupExtensionName(XamlContext ctx, XElement parent, bool isFullName = true) {
+			if (!isFullName)
+				return XmlConvert.EncodeLocalName(PropertyName);
+
+			var sb = new StringBuilder();
+			if (DeclaringType.Namespace != parent.GetDefaultNamespace()) {
+				var prefix = parent.GetPrefixOfNamespace(DeclaringType.Namespace);
+				if (!string.IsNullOrEmpty(prefix)) {
+					sb.Append(prefix);
+					sb.Append(':');
+				}
+			}
+
+			DeclaringType.TypeName.AppendEncodedName(sb);
+			sb.Append('.');
+			sb.Append(XmlConvert.EncodeLocalName(PropertyName));
+			return sb.ToString();
 		}
 
 		public override string ToString() => PropertyName;

--- a/Extensions/dnSpy.BamlDecompiler/Xaml/XamlType.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Xaml/XamlType.cs
@@ -20,6 +20,7 @@
 	THE SOFTWARE.
 */
 
+using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using dnlib.DotNet;
@@ -29,16 +30,16 @@ namespace dnSpy.BamlDecompiler.Xaml {
 	sealed class XamlType {
 		public IAssembly Assembly { get; }
 		public string TypeNamespace { get; }
-		public string TypeName { get; }
+		public XamlTypeName TypeName { get; }
 
 		public XNamespace Namespace { get; private set; }
 		public ITypeDefOrRef ResolvedType { get; set; }
 
-		public XamlType(IAssembly assembly, string ns, string name)
+		public XamlType(IAssembly assembly, string ns, XamlTypeName name)
 			: this(assembly, ns, name, null) {
 		}
 
-		public XamlType(IAssembly assembly, string ns, string name, XNamespace xmlns) {
+		public XamlType(IAssembly assembly, string ns, XamlTypeName name, XNamespace xmlns) {
 			Assembly = assembly;
 			TypeNamespace = ns;
 			TypeName = name;
@@ -96,6 +97,21 @@ namespace dnSpy.BamlDecompiler.Xaml {
 			if (Namespace is null)
 				return XmlConvert.EncodeLocalName(TypeName);
 			return Namespace + XmlConvert.EncodeLocalName(TypeName);
+		}
+
+		public string ToMarkupExtensionName(XamlContext ctx, XElement elem) {
+			ResolveNamespace(elem, ctx);
+
+			var sb = new StringBuilder();
+			if (Namespace != elem.GetDefaultNamespace()) {
+				var prefix = elem.GetPrefixOfNamespace(Namespace);
+				if (!string.IsNullOrEmpty(prefix)) {
+					sb.Append(prefix);
+					sb.Append(':');
+				}
+			}
+
+			return TypeName.AppendEncodedName(sb).ToString();
 		}
 
 		public override string ToString() => TypeName;

--- a/Extensions/dnSpy.BamlDecompiler/Xaml/XamlTypeName.cs
+++ b/Extensions/dnSpy.BamlDecompiler/Xaml/XamlTypeName.cs
@@ -1,0 +1,76 @@
+/*
+	Copyright (c) 2023 ElektroKill
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in
+	all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+	THE SOFTWARE.
+*/
+
+
+using System.Collections.Generic;
+using System.Text;
+using System.Xml;
+using dnlib.DotNet;
+
+namespace dnSpy.BamlDecompiler.Xaml {
+	public sealed class XamlTypeName {
+		public string[] DeclaringTypeNames { get; }
+
+		public string TypeName { get; }
+
+		XamlTypeName(string[] declaringTypeNames, string typeName) {
+			DeclaringTypeNames = declaringTypeNames;
+			TypeName = typeName;
+		}
+
+		public static XamlTypeName From(ITypeDefOrRef type, out string clrNs) {
+			var typeName = type.ReflectionName;
+
+			var declaringTypes = new List<string>();
+			while (type.DeclaringType is ITypeDefOrRef declaringType) {
+				declaringTypes.Insert(0, declaringType.ReflectionName);
+				type = declaringType;
+			}
+
+			clrNs = type.ReflectionNamespace;
+			return new XamlTypeName(declaringTypes.ToArray(), typeName);
+		}
+
+		public string ToEncodedName() => AppendEncodedName(new StringBuilder()).ToString();
+
+		public StringBuilder AppendEncodedName(StringBuilder sb) {
+			for (var i = 0; i < DeclaringTypeNames.Length; i++) {
+				sb.Append(XmlConvert.EncodeLocalName(DeclaringTypeNames[i]));
+				sb.Append('+');
+			}
+			sb.Append(XmlConvert.EncodeLocalName(TypeName));
+			return sb;
+		}
+
+		public static implicit operator string(XamlTypeName typeName) => typeName.ToString();
+
+		public override string ToString() {
+			var sb = new StringBuilder();
+			for (var i = 0; i < DeclaringTypeNames.Length; i++) {
+				sb.Append(DeclaringTypeNames[i]);
+				sb.Append('+');
+			}
+			sb.Append(TypeName);
+			return sb.ToString();
+		}
+	}
+}

--- a/Extensions/dnSpy.BamlDecompiler/XamlContext.cs
+++ b/Extensions/dnSpy.BamlDecompiler/XamlContext.cs
@@ -89,15 +89,6 @@ namespace dnSpy.BamlDecompiler {
 			}
 		}
 
-		static string NestedReflectionName(ITypeDefOrRef type, out string clrNs) {
-			var name = type.ReflectionFullName;
-			while (type.DeclaringType is ITypeDefOrRef declaringType)
-				type = declaringType;
-			clrNs = type.ReflectionNamespace;
-			name = name.Substring(clrNs.Length + 1);
-			return name;
-		}
-		
 		public XamlType ResolveType(ushort id) {
 			if (typeMap.TryGetValue(id, out var xamlType))
 				return xamlType;
@@ -115,7 +106,7 @@ namespace dnSpy.BamlDecompiler {
 				type = TypeNameParser.ParseReflectionThrow(Module, typeRec.TypeFullName, new DummyAssemblyRefFinder(assembly));
 			}
 
-			var name = NestedReflectionName(type, out string clrNs);
+			var name = XamlTypeName.From(type, out string clrNs);
 			var xmlNs = XmlNs.LookupXmlns(assembly, clrNs);
 
 			typeMap[id] = xamlType = new XamlType(assembly, clrNs, name, GetXmlNamespace(xmlNs)) {

--- a/Extensions/dnSpy.BamlDecompiler/XamlOutputCreator.cs
+++ b/Extensions/dnSpy.BamlDecompiler/XamlOutputCreator.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 using dnSpy.Contracts.Decompiler;
@@ -44,12 +45,98 @@ namespace dnSpy.BamlDecompiler {
 				OmitXmlDeclaration = true,
 			};
 			using (var writer = new StringWriter(CultureInfo.InvariantCulture)) {
-				using (var xmlWriter = XmlWriter.Create(writer, settings))
+				using (var xmlWriter = new XmlWriterWithMarkupExtensionSupport(XmlWriter.Create(writer, settings)))
 					document.WriteTo(xmlWriter);
 				// WriteTo() doesn't add a final newline
 				writer.WriteLine();
 				return writer.ToString();
 			}
 		}
+	}
+
+	sealed class XmlWriterWithMarkupExtensionSupport : XmlWriter {
+		readonly XmlWriter writer;
+		bool inAttribute;
+
+		public XmlWriterWithMarkupExtensionSupport(XmlWriter baseWriter) => writer = baseWriter ?? throw new ArgumentNullException(nameof(baseWriter));
+
+		public override void WriteStartAttribute(string prefix, string localName, string ns) {
+			inAttribute = true;
+			writer.WriteStartAttribute(prefix, localName, ns);
+		}
+
+		public override void WriteEndAttribute() {
+			inAttribute = false;
+			writer.WriteEndAttribute();
+		}
+
+		public override void WriteString(string text) {
+			if (inAttribute && text.Length > 3 && text[0] == '{' && text[1] != '}' && text[text.Length - 1] == '}')
+				writer.WriteRaw(text);
+			else
+				writer.WriteString(text);
+		}
+
+		protected override void Dispose(bool disposing) {
+			if (!disposing)
+				return;
+			writer.Dispose();
+		}
+
+		public override XmlWriterSettings Settings => writer.Settings;
+		public override WriteState WriteState => writer.WriteState;
+		public override XmlSpace XmlSpace => writer.XmlSpace;
+		public override string XmlLang => writer.XmlLang;
+		public override void WriteStartDocument() => writer.WriteStartDocument();
+		public override void WriteStartDocument(bool standalone) => writer.WriteStartDocument(standalone);
+		public override void WriteEndDocument() => writer.WriteEndDocument();
+		public override void WriteDocType(string name, string pubid, string sysid, string subset) => writer.WriteDocType(name, pubid, sysid, subset);
+		public override void WriteStartElement(string prefix, string localName, string ns) => writer.WriteStartElement(prefix, localName, ns);
+		public override void WriteEndElement() => writer.WriteEndElement();
+		public override void WriteFullEndElement() => writer.WriteFullEndElement();
+		public override void WriteCData(string text) => writer.WriteCData(text);
+		public override void WriteComment(string text) => writer.WriteComment(text);
+		public override void WriteProcessingInstruction(string name, string text) => writer.WriteProcessingInstruction(name, text);
+		public override void WriteEntityRef(string name) => writer.WriteEntityRef(name);
+		public override void WriteCharEntity(char ch) => writer.WriteCharEntity(ch);
+		public override void WriteWhitespace(string ws) => writer.WriteWhitespace(ws);
+		public override void WriteSurrogateCharEntity(char lowChar, char highChar) => writer.WriteSurrogateCharEntity(lowChar, highChar);
+		public override void WriteChars(char[] buffer, int index, int count) => writer.WriteChars(buffer, index, count);
+		public override void WriteRaw(char[] buffer, int index, int count) => writer.WriteRaw(buffer, index, count);
+		public override void WriteRaw(string data) => writer.WriteRaw(data);
+		public override void WriteBase64(byte[] buffer, int index, int count) => writer.WriteBase64(buffer, index, count);
+		public override void Close() => writer.Close();
+		public override void Flush() => writer.Flush();
+		public override string LookupPrefix(string ns) => writer.LookupPrefix(ns);
+		public override void WriteValue(object value) => writer.WriteValue(value);
+		public override void WriteValue(string value) => writer.WriteValue(value);
+		public override void WriteValue(bool value) => writer.WriteValue(value);
+		public override void WriteValue(DateTime value) => writer.WriteValue(value);
+		public override void WriteValue(DateTimeOffset value) => writer.WriteValue(value);
+		public override void WriteValue(double value) => writer.WriteValue(value);
+		public override void WriteValue(float value) => writer.WriteValue(value);
+		public override void WriteValue(Decimal value) => writer.WriteValue(value);
+		public override void WriteValue(int value) => writer.WriteValue(value);
+		public override void WriteValue(long value) => writer.WriteValue(value);
+		public override Task WriteStartDocumentAsync() => writer.WriteStartDocumentAsync();
+		public override Task WriteStartDocumentAsync(bool standalone) => writer.WriteStartDocumentAsync(standalone);
+		public override Task WriteEndDocumentAsync() => writer.WriteEndDocumentAsync();
+		public override Task WriteDocTypeAsync(string name, string pubid, string sysid, string subset) => writer.WriteDocTypeAsync(name, pubid, sysid, subset);
+		public override Task WriteStartElementAsync(string prefix, string localName, string ns) => writer.WriteStartElementAsync(prefix, localName, ns);
+		public override Task WriteEndElementAsync() => writer.WriteEndElementAsync();
+		public override Task WriteFullEndElementAsync() => writer.WriteFullEndElementAsync();
+		public override Task WriteCDataAsync(string text) => writer.WriteCDataAsync(text);
+		public override Task WriteCommentAsync(string text) => writer.WriteCommentAsync(text);
+		public override Task WriteProcessingInstructionAsync(string name, string text) => writer.WriteProcessingInstructionAsync(name, text);
+		public override Task WriteEntityRefAsync(string name) => writer.WriteEntityRefAsync(name);
+		public override Task WriteCharEntityAsync(char ch) => writer.WriteCharEntityAsync(ch);
+		public override Task WriteWhitespaceAsync(string ws) => writer.WriteWhitespaceAsync(ws);
+		public override Task WriteStringAsync(string text) => writer.WriteStringAsync(text);
+		public override Task WriteSurrogateCharEntityAsync(char lowChar, char highChar) => writer.WriteSurrogateCharEntityAsync(lowChar, highChar);
+		public override Task WriteCharsAsync(char[] buffer, int index, int count) => writer.WriteCharsAsync(buffer, index, count);
+		public override Task WriteRawAsync(char[] buffer, int index, int count) => writer.WriteRawAsync(buffer, index, count);
+		public override Task WriteRawAsync(string data) => writer.WriteRawAsync(data);
+		public override Task WriteBase64Async(byte[] buffer, int index, int count) => writer.WriteBase64Async(buffer, index, count);
+		public override Task FlushAsync() => writer.FlushAsync();
 	}
 }

--- a/dnSpy/dnSpy/Documents/Tabs/DocViewer/XmlParser.XamlAttributeParser.cs
+++ b/dnSpy/dnSpy/Documents/Tabs/DocViewer/XmlParser.XamlAttributeParser.cs
@@ -333,7 +333,7 @@ namespace dnSpy.Documents.Tabs.DocViewer {
 					return new Token(new Span(startPos, 1), TokenKind.Period);
 				if (c == '=')
 					return new Token(new Span(startPos, 1), TokenKind.Equals);
-				if (c == '\'' )
+				if (c == '\'')
 					return new Token(new Span(startPos, 1), TokenKind.SingleQuote);
 				if (c == '"')
 					return new Token(new Span(startPos, 1), TokenKind.DoubleQuote);

--- a/dnSpy/dnSpy/Documents/Tabs/DocViewer/XmlParser.XamlAttributeParser.cs
+++ b/dnSpy/dnSpy/Documents/Tabs/DocViewer/XmlParser.XamlAttributeParser.cs
@@ -140,6 +140,12 @@ namespace dnSpy.Documents.Tabs.DocViewer {
 					return;
 				}
 
+				var nextToken = PeekToken();
+				if (nextToken.Kind == TokenKind.CloseCurlyBrace) {
+					owner.SaveBraceInfo(openCurlyBraceToken.Span, nextToken.Span, CodeBracesRangeFlags.OtherBlockBraces);
+					return;
+				}
+
 				try {
 					var markupExtName = ReadNameToken();
 					if (markupExtName is null) {

--- a/dnSpy/dnSpy/Documents/Tabs/DocViewer/XmlParser.XamlAttributeParser.cs
+++ b/dnSpy/dnSpy/Documents/Tabs/DocViewer/XmlParser.XamlAttributeParser.cs
@@ -317,7 +317,7 @@ namespace dnSpy.Documents.Tabs.DocViewer {
 			}
 
 			bool IsNameStartChar(char c) => char.IsLetter(c) || c == '_';
-			bool IsNameChar(char c) => char.IsLetterOrDigit(c) || c == '_';
+			bool IsNameChar(char c) => char.IsLetterOrDigit(c) || c == '_' || c == '+';
 
 			void SkipWhitespace() {
 				for (;;) {


### PR DESCRIPTION
Link to issue(s) this pull request covers:
N/A

### Problem
There were several issues with the markup extension decompilation produced by dnSpyEx.
1. Nested type delimiter was being incorrectly escaped resulting in incorrect decompilation.
2. Strings with spaces in markup extensions were not wrapped in quotes leading to invalid decompilation.
3. Characters like `<`were being escaped in markup extensions in cases where they shouldn't be.

### Solution
All problems mentioned above were solved by modifying the decompiler as well as creating a custom wrapper for `XmlWriter`.
