### PR TITLE
Set `EnableWindowsTargeting` to `true`

### DIFF
--- a/DnSpyCommon.props
+++ b/DnSpyCommon.props
@@ -23,6 +23,9 @@
     <DnSpyRuntimeIdentifiers>win-x86;win-x64</DnSpyRuntimeIdentifiers>
     <SatelliteResourceLanguages>cs;de;es;es-ES;fa;fr;hu;it;pt-BR;pt-PT;ru;tr;uk;zh-CN;vi</SatelliteResourceLanguages>
 
+    <!-- Allow compiling for windows on non-windows platforms -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+
     <!-- Enable Visual Studio Build Acceleration -->
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>


### PR DESCRIPTION
Link to issue(s) this pull request covers:
https://github.com/dnSpyEx/dnSpy/issues/222

### Problem
dnSpy did not compile on macOS, or other non-windows platforms due to missing targeting packs.

### Solution
Setting `EnableWindowsTargeting` to `true` allows the target packs to be downloaded and used when building dnSpy using `dotnet build` on platforms other than Windows.

It is worth mentioning that the builds compiled on non-Windows platforms are not 1:1 to the builds compiled on Windows due to the limitations mentioned in the note here:
https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#enablewindowstargeting
Most notable of which is the presence of the console dialog when launching the compiled version on Windows due to the subsystem field in the PE being set incorrectly to `WindowsCui` instead of `WindowsGui` and the missing Win32 resources which cause the file icon as well as properties to be blank on Windows.

@pardeike Could you please verify if the changes in this PR allow you to compile dnSpy on macOS?
