### PR TITLE
Extend support for custom type information in the debugger

### DIFF
--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Evaluation/Engine/DbgDotNetEngineValueNodeFactory.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Evaluation/Engine/DbgDotNetEngineValueNodeFactory.cs
@@ -53,7 +53,7 @@ namespace dnSpy.Debugger.DotNet.Evaluation.Engine {
 
 		internal DbgEngineValueNode Create(DbgDotNetValueNode node) => new DbgEngineValueNodeImpl(this, node);
 
-		public override DbgEngineValueNode Create(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType, DbgDotNetCustomTypeInfo customTypeInfo) =>
+		public override DbgEngineValueNode Create(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType, DbgDotNetCustomTypeInfo? customTypeInfo) =>
 			new DbgEngineValueNodeImpl(this, factory.Create(evalInfo, name, value, formatSpecifiers, options, expression, imageName, isReadOnly, causesSideEffects, expectedType, customTypeInfo));
 
 		public override DbgEngineValueNode CreateException(DbgEvaluationInfo evalInfo, uint id, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options) =>

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Evaluation/Engine/DbgDotNetEngineValueNodeFactory.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Evaluation/Engine/DbgDotNetEngineValueNodeFactory.cs
@@ -30,7 +30,7 @@ using dnSpy.Debugger.DotNet.Metadata;
 
 namespace dnSpy.Debugger.DotNet.Evaluation.Engine {
 	abstract class DbgDotNetEngineValueNodeFactory {
-		public abstract DbgEngineValueNode Create(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType);
+		public abstract DbgEngineValueNode Create(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType, DbgDotNetCustomTypeInfo? customTypeInfo);
 		public abstract DbgEngineValueNode CreateException(DbgEvaluationInfo evalInfo, uint id, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options);
 		public abstract DbgEngineValueNode CreateStowedException(DbgEvaluationInfo evalInfo, uint id, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options);
 		public abstract DbgEngineValueNode CreateReturnValue(DbgEvaluationInfo evalInfo, uint id, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, DmdMethodBase method);
@@ -53,8 +53,8 @@ namespace dnSpy.Debugger.DotNet.Evaluation.Engine {
 
 		internal DbgEngineValueNode Create(DbgDotNetValueNode node) => new DbgEngineValueNodeImpl(this, node);
 
-		public override DbgEngineValueNode Create(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType) =>
-			new DbgEngineValueNodeImpl(this, factory.Create(evalInfo, name, value, formatSpecifiers, options, expression, imageName, isReadOnly, causesSideEffects, expectedType));
+		public override DbgEngineValueNode Create(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType, DbgDotNetCustomTypeInfo customTypeInfo) =>
+			new DbgEngineValueNodeImpl(this, factory.Create(evalInfo, name, value, formatSpecifiers, options, expression, imageName, isReadOnly, causesSideEffects, expectedType, customTypeInfo));
 
 		public override DbgEngineValueNode CreateException(DbgEvaluationInfo evalInfo, uint id, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options) =>
 			new DbgEngineValueNodeImpl(this, factory.CreateException(evalInfo, id, value, formatSpecifiers, options));

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Evaluation/Engine/DbgDotNetValueCreator.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Evaluation/Engine/DbgDotNetValueCreator.cs
@@ -51,7 +51,7 @@ namespace dnSpy.Debugger.DotNet.Evaluation.Engine {
 					if (res.ErrorMessage is not null)
 						return valueNodeFactory.CreateError(evalInfo, compExprInfo.Name, res.ErrorMessage, compExprInfo.Expression, (compExprInfo.Flags & DbgEvaluationResultFlags.SideEffects) != 0);
 					//TODO: Pass in compExprInfo.CustomTypeInfo, or attach it to the DbgDotNetValueNode
-					return valueNodeFactory.Create(evalInfo, compExprInfo.Name, res.Value!, compExprInfo.FormatSpecifiers, nodeOptions, compExprInfo.Expression, compExprInfo.ImageName, (compExprInfo.Flags & DbgEvaluationResultFlags.ReadOnly) != 0, (compExprInfo.Flags & DbgEvaluationResultFlags.SideEffects) != 0, expectedType);
+					return valueNodeFactory.Create(evalInfo, compExprInfo.Name, res.Value!, compExprInfo.FormatSpecifiers, nodeOptions, compExprInfo.Expression, compExprInfo.ImageName, (compExprInfo.Flags & DbgEvaluationResultFlags.ReadOnly) != 0, (compExprInfo.Flags & DbgEvaluationResultFlags.SideEffects) != 0, expectedType, compExprInfo.CustomTypeInfo);
 				}
 				catch {
 					res.Value?.Dispose();

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Evaluation/Engine/DbgEngineLanguageImpl.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Evaluation/Engine/DbgEngineLanguageImpl.cs
@@ -123,7 +123,7 @@ namespace dnSpy.Debugger.DotNet.Evaluation.Engine {
 			Debug2.Assert(context.Runtime.GetDotNetRuntime() is not null);
 
 			IDebuggerDisplayAttributeEvaluatorUtils.Initialize(context, debuggerDisplayAttributeEvaluator);
-			// Needed by DebuggerRuntimeImpl (calls expressionCompiler.TryGetAliasInfo()) and DbgCorDebugInternalRuntimeImpl (calls expressionCompiler.CreateCustomTypeInfo())
+			// Needed by DebuggerRuntimeImpl (calls expressionCompiler.TryGetAliasInfo()), DbgCorDebugInternalRuntimeImpl and DbgEngineStaticFieldsProviderImpl (calls expressionCompiler.CreateCustomTypeInfo())
 			context.GetOrCreateData(() => expressionCompiler);
 
 			if ((context.Options & DbgEvaluationContextOptions.NoMethodBody) == 0 && location is IDbgDotNetCodeLocation loc) {

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Evaluation/Engine/DbgEngineStaticFieldsProviderImpl.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Evaluation/Engine/DbgEngineStaticFieldsProviderImpl.cs
@@ -89,7 +89,7 @@ namespace dnSpy.Debugger.DotNet.Evaluation.Engine {
 					if (fieldVal.HasError)
 						valueNodes[j++] = valueNodeFactory.CreateError(evalInfo, fieldExpression, fieldVal.ErrorMessage!, fieldExpression.ToString(), false);
 					else
-						valueNodes[j++] = valueNodeFactory.Create(evalInfo, fieldExpression, fieldVal.Value!, null, options, fieldExpression.ToString(), GetFieldImageName(field), false, false, field.FieldType);
+						valueNodes[j++] = valueNodeFactory.Create(evalInfo, fieldExpression, fieldVal.Value!, null, options, fieldExpression.ToString(), GetFieldImageName(field), false, false, field.FieldType, null); // TODO:
 				}
 				ObjectCache.Free(ref output);
 

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Evaluation/Engine/DbgEngineStaticFieldsProviderImpl.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Evaluation/Engine/DbgEngineStaticFieldsProviderImpl.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using dnlib.DotNet.Emit;
 using dnSpy.Contracts.Debugger;
 using dnSpy.Contracts.Debugger.DotNet.Evaluation;
+using dnSpy.Contracts.Debugger.DotNet.Evaluation.ExpressionCompiler;
 using dnSpy.Contracts.Debugger.DotNet.Evaluation.Formatters;
 using dnSpy.Contracts.Debugger.Engine.Evaluation;
 using dnSpy.Contracts.Debugger.Evaluation;
@@ -88,8 +89,10 @@ namespace dnSpy.Debugger.DotNet.Evaluation.Engine {
 
 					if (fieldVal.HasError)
 						valueNodes[j++] = valueNodeFactory.CreateError(evalInfo, fieldExpression, fieldVal.ErrorMessage!, fieldExpression.ToString(), false);
-					else
-						valueNodes[j++] = valueNodeFactory.Create(evalInfo, fieldExpression, fieldVal.Value!, null, options, fieldExpression.ToString(), GetFieldImageName(field), false, false, field.FieldType, null); // TODO:
+					else {
+						evalInfo.Context.TryGetData(out DbgDotNetExpressionCompiler? expressionCompiler);
+						valueNodes[j++] = valueNodeFactory.Create(evalInfo, fieldExpression, fieldVal.Value!, null, options, fieldExpression.ToString(), GetFieldImageName(field), false, false, field.FieldType, expressionCompiler?.CreateCustomTypeInfo(field));
+					}
 				}
 				ObjectCache.Free(ref output);
 

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Evaluation/Engine/DbgEngineValueNodeFactoryImpl.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet/Evaluation/Engine/DbgEngineValueNodeFactoryImpl.cs
@@ -64,7 +64,7 @@ namespace dnSpy.Debugger.DotNet.Evaluation.Engine {
 						newNode = valueNodeFactory.CreateError(evalInfo, evalRes.Name, evalRes.Error, info.Expression, causesSideEffects);
 					else {
 						bool isReadOnly = (evalRes.Flags & DbgEvaluationResultFlags.ReadOnly) != 0;
-						newNode = valueNodeFactory.Create(evalInfo, evalRes.Name, evalRes.Value!, evalRes.FormatSpecifiers, info.NodeOptions, info.Expression, evalRes.ImageName, isReadOnly, causesSideEffects, evalRes.Type!);
+						newNode = valueNodeFactory.Create(evalInfo, evalRes.Name, evalRes.Value!, evalRes.FormatSpecifiers, info.NodeOptions, info.Expression, evalRes.ImageName, isReadOnly, causesSideEffects, evalRes.Type!, evalRes.CustomTypeInfo);
 					}
 					res[i] = newNode;
 				}
@@ -109,7 +109,7 @@ namespace dnSpy.Debugger.DotNet.Evaluation.Engine {
 					if (objectIdValue is null)
 						res[i] = valueNodeFactory.CreateError(evalInfo, name, "Could not get Object ID value", expression, false);
 					else
-						res[i] = valueNodeFactory.Create(evalInfo, name, objectIdValue, null, options, expression, PredefinedDbgValueNodeImageNames.ObjectId, true, false, objectIdValue.Type);
+						res[i] = valueNodeFactory.Create(evalInfo, name, objectIdValue, null, options, expression, PredefinedDbgValueNodeImageNames.ObjectId, true, false, objectIdValue.Type, null);
 				}
 				ObjectCache.Free(ref output);
 				return res;

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/AdditionalTypeInfoState.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/AdditionalTypeInfoState.cs
@@ -7,5 +7,29 @@ namespace dnSpy.Roslyn.Debugger.Formatters {
 		internal int TupleNameIndex;
 
 		public AdditionalTypeInfoState(IAdditionalTypeInfoProvider? typeInfoProvider) => TypeInfoProvider = typeInfoProvider;
+
+		public override bool Equals(object? obj) {
+			if (obj is not AdditionalTypeInfoState other)
+				return false;
+			if (!Equals(TypeInfoProvider, other.TypeInfoProvider))
+				return false;
+			if (DynamicTypeIndex != other.DynamicTypeIndex)
+				return false;
+			if (NativeIntTypeIndex != other.NativeIntTypeIndex)
+				return false;
+			if (TupleNameIndex != other.TupleNameIndex)
+				return false;
+			return true;
+		}
+
+		public override int GetHashCode() {
+			unchecked {
+				int hashCode = TypeInfoProvider is not null ? TypeInfoProvider.GetHashCode() : 0;
+				hashCode = hashCode * 397 ^ DynamicTypeIndex;
+				hashCode = hashCode * 397 ^ NativeIntTypeIndex;
+				hashCode = hashCode * 397 ^ TupleNameIndex;
+				return hashCode;
+			}
+		}
 	}
 }

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/AdditionalTypeInfoState.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/AdditionalTypeInfoState.cs
@@ -1,3 +1,22 @@
+/*
+    Copyright (C) 2023 ElektroKill
+
+    This file is part of dnSpy
+
+    dnSpy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    dnSpy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 namespace dnSpy.Roslyn.Debugger.Formatters {
 	struct AdditionalTypeInfoState {
 		internal readonly IAdditionalTypeInfoProvider? TypeInfoProvider;

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/AdditionalTypeInfoState.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/AdditionalTypeInfoState.cs
@@ -1,0 +1,11 @@
+namespace dnSpy.Roslyn.Debugger.Formatters {
+	struct AdditionalTypeInfoState {
+		internal readonly IAdditionalTypeInfoProvider? TypeInfoProvider;
+
+		internal int DynamicTypeIndex;
+		internal int NativeIntTypeIndex;
+		internal int TupleNameIndex;
+
+		public AdditionalTypeInfoState(IAdditionalTypeInfoProvider? typeInfoProvider) => TypeInfoProvider = typeInfoProvider;
+	}
+}

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/CSharp/CSharpFormatter.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/CSharp/CSharpFormatter.cs
@@ -27,8 +27,8 @@ using dnSpy.Debugger.DotNet.Metadata;
 namespace dnSpy.Roslyn.Debugger.Formatters.CSharp {
 	[ExportDbgDotNetFormatter(DbgDotNetLanguageGuids.CSharp)]
 	sealed class CSharpFormatter : LanguageFormatter {
-		public override void FormatType(DbgEvaluationInfo evalInfo, IDbgTextWriter output, DmdType type, DbgDotNetValue? value, DbgValueFormatterTypeOptions options, CultureInfo? cultureInfo) =>
-			new CSharpTypeFormatter(output, options.ToTypeFormatterOptions(), cultureInfo).Format(type, value);
+		public override void FormatType(DbgEvaluationInfo evalInfo, IDbgTextWriter output, DmdType type, AdditionalTypeInfoState additionalTypeInfo, DbgDotNetValue? value, DbgValueFormatterTypeOptions options, CultureInfo? cultureInfo) =>
+			new CSharpTypeFormatter(output, options.ToTypeFormatterOptions(), cultureInfo).Format(type, additionalTypeInfo, value);
 
 		public override void FormatValue(DbgEvaluationInfo evalInfo, IDbgTextWriter output, DbgDotNetValue value, DbgValueFormatterOptions options, CultureInfo? cultureInfo) =>
 			new CSharpValueFormatter(output, evalInfo, this, options.ToValueFormatterOptions(), cultureInfo).Format(value);

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/CSharp/CSharpTypeFormatter.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/CSharp/CSharpTypeFormatter.cs
@@ -115,9 +115,11 @@ namespace dnSpy.Roslyn.Debugger.Formatters.CSharp {
 
 		void WriteIdentifier(string? id, DbgTextColor color) => OutputWrite(GetFormattedIdentifier(id), color);
 
-		public void Format(DmdType type, DbgDotNetValue? value = null, IAdditionalTypeInfoProvider? additionalTypeInfoProvider = null, DmdParameterInfo? pd = null, bool forceReadOnly = false) {
+		public void Format(DmdType type, DbgDotNetValue? value = null, IAdditionalTypeInfoProvider? additionalTypeInfoProvider = null, DmdParameterInfo? pd = null, bool forceReadOnly = false) =>
+			Format(type, new AdditionalTypeInfoState(additionalTypeInfoProvider), value, pd, forceReadOnly);
+
+		public void Format(DmdType type, AdditionalTypeInfoState state, DbgDotNetValue? value = null, DmdParameterInfo? pd = null, bool forceReadOnly = false) {
 			WriteRefIfByRef(type, pd, forceReadOnly);
-			var state = new AdditionalTypeInfoState(additionalTypeInfoProvider);
 			if (type.IsByRef) {
 				type = type.GetElementType()!;
 				state.DynamicTypeIndex++;

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/CustomAttributeAdditionalTypeInfoProvider.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/CustomAttributeAdditionalTypeInfoProvider.cs
@@ -1,4 +1,24 @@
-﻿using System.Collections.Generic;
+﻿/*
+    Copyright (C) 2023 ElektroKill
+
+    This file is part of dnSpy
+
+    dnSpy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    dnSpy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using dnSpy.Debugger.DotNet.Metadata;
 

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/CustomTypeInfoAdditionalTypeInfoProvider.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/CustomTypeInfoAdditionalTypeInfoProvider.cs
@@ -1,0 +1,24 @@
+using System.Collections.ObjectModel;
+using dnSpy.Contracts.Debugger.DotNet.Evaluation;
+using Microsoft.CodeAnalysis.ExpressionEvaluator;
+
+namespace dnSpy.Roslyn.Debugger.Formatters {
+	sealed class CustomTypeInfoAdditionalTypeInfoProvider : IAdditionalTypeInfoProvider {
+		readonly ReadOnlyCollection<byte>? dynamicFlags;
+		readonly ReadOnlyCollection<string?>? tupleElementNames;
+
+		CustomTypeInfoAdditionalTypeInfoProvider(DbgDotNetCustomTypeInfo customTypeInfo) => CustomTypeInfo.Decode(customTypeInfo.CustomTypeInfoId, customTypeInfo.CustomTypeInfo, out dynamicFlags, out tupleElementNames);
+
+		public static CustomTypeInfoAdditionalTypeInfoProvider? TryCreate(DbgDotNetCustomTypeInfo customTypeInfo) {
+			if (customTypeInfo.CustomTypeInfoId != CustomTypeInfo.PayloadTypeId)
+				return null;
+			return new CustomTypeInfoAdditionalTypeInfoProvider(customTypeInfo);
+		}
+
+		public bool IsDynamicType(int typeIndex) => DynamicFlagsCustomTypeInfo.GetFlag(dynamicFlags, typeIndex);
+
+		public string? GetTupleElementName(int typeIndex) => CustomTypeInfo.GetTupleElementNameIfAny(tupleElementNames, typeIndex);
+
+		public bool IsNativeIntegerType(int typeIndex) => false;
+	}
+}

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/CustomTypeInfoAdditionalTypeInfoProvider.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/CustomTypeInfoAdditionalTypeInfoProvider.cs
@@ -4,13 +4,17 @@ using Microsoft.CodeAnalysis.ExpressionEvaluator;
 
 namespace dnSpy.Roslyn.Debugger.Formatters {
 	sealed class CustomTypeInfoAdditionalTypeInfoProvider : IAdditionalTypeInfoProvider {
+		readonly DbgDotNetCustomTypeInfo customTypeInfo;
 		readonly ReadOnlyCollection<byte>? dynamicFlags;
 		readonly ReadOnlyCollection<string?>? tupleElementNames;
 
-		CustomTypeInfoAdditionalTypeInfoProvider(DbgDotNetCustomTypeInfo customTypeInfo) => CustomTypeInfo.Decode(customTypeInfo.CustomTypeInfoId, customTypeInfo.CustomTypeInfo, out dynamicFlags, out tupleElementNames);
+		CustomTypeInfoAdditionalTypeInfoProvider(DbgDotNetCustomTypeInfo customTypeInfo) {
+			this.customTypeInfo = customTypeInfo;
+			CustomTypeInfo.Decode(customTypeInfo.CustomTypeInfoId, customTypeInfo.CustomTypeInfo, out dynamicFlags, out tupleElementNames);
+		}
 
-		public static CustomTypeInfoAdditionalTypeInfoProvider? TryCreate(DbgDotNetCustomTypeInfo customTypeInfo) {
-			if (customTypeInfo.CustomTypeInfoId != CustomTypeInfo.PayloadTypeId)
+		public static CustomTypeInfoAdditionalTypeInfoProvider? TryCreate(DbgDotNetCustomTypeInfo? customTypeInfo) {
+			if (customTypeInfo?.CustomTypeInfoId != CustomTypeInfo.PayloadTypeId)
 				return null;
 			return new CustomTypeInfoAdditionalTypeInfoProvider(customTypeInfo);
 		}
@@ -20,5 +24,13 @@ namespace dnSpy.Roslyn.Debugger.Formatters {
 		public string? GetTupleElementName(int typeIndex) => CustomTypeInfo.GetTupleElementNameIfAny(tupleElementNames, typeIndex);
 
 		public bool IsNativeIntegerType(int typeIndex) => false;
+
+		public override bool Equals(object? obj) {
+			if (ReferenceEquals(this, obj))
+				return true;
+			return obj is CustomTypeInfoAdditionalTypeInfoProvider other && customTypeInfo.Equals(other.customTypeInfo);
+		}
+
+		public override int GetHashCode() => customTypeInfo.GetHashCode();
 	}
 }

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/CustomTypeInfoAdditionalTypeInfoProvider.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/CustomTypeInfoAdditionalTypeInfoProvider.cs
@@ -1,3 +1,23 @@
+/*
+    Copyright (C) 2023 ElektroKill
+
+    This file is part of dnSpy
+
+    dnSpy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    dnSpy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
 using System.Collections.ObjectModel;
 using dnSpy.Contracts.Debugger.DotNet.Evaluation;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/IAdditionalTypeInfoProvider.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/IAdditionalTypeInfoProvider.cs
@@ -1,4 +1,23 @@
-﻿namespace dnSpy.Roslyn.Debugger.Formatters {
+﻿/*
+    Copyright (C) 2023 ElektroKill
+
+    This file is part of dnSpy
+
+    dnSpy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    dnSpy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace dnSpy.Roslyn.Debugger.Formatters {
 	interface IAdditionalTypeInfoProvider {
 		bool IsDynamicType(int typeIndex);
 		string? GetTupleElementName(int typeIndex);

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/LanguageFormatter.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/LanguageFormatter.cs
@@ -1,28 +1,36 @@
 /*
-    Copyright (C) 2014-2019 de4dot@gmail.com
+	Copyright (C) 2014-2019 de4dot@gmail.com
 
-    This file is part of dnSpy
+	This file is part of dnSpy
 
-    dnSpy is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+	dnSpy is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
 
-    dnSpy is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+	dnSpy is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+	You should have received a copy of the GNU General Public License
+	along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using System.Globalization;
+using dnSpy.Contracts.Debugger.DotNet.Evaluation;
 using dnSpy.Contracts.Debugger.DotNet.Evaluation.Formatters;
 using dnSpy.Contracts.Debugger.Evaluation;
 using dnSpy.Contracts.Debugger.Text;
+using dnSpy.Debugger.DotNet.Metadata;
 
 namespace dnSpy.Roslyn.Debugger.Formatters {
 	abstract class LanguageFormatter : DbgDotNetFormatter {
+		public override void FormatType(DbgEvaluationInfo evalInfo, IDbgTextWriter output, DmdType type,DbgDotNetValue? value, DbgValueFormatterTypeOptions options, CultureInfo? cultureInfo) =>
+			FormatType(evalInfo, output, type, default, value, options, cultureInfo);
+
+		public abstract void FormatType(DbgEvaluationInfo evalInfo, IDbgTextWriter output, DmdType type, AdditionalTypeInfoState additionalTypeInfo, DbgDotNetValue? value, DbgValueFormatterTypeOptions options, CultureInfo? cultureInfo);
+
 		public override void FormatExceptionName(DbgEvaluationContext context, IDbgTextWriter output, uint id) =>
 			output.Write(DbgTextColor.ExceptionName, AliasConstants.ExceptionName);
 

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/VisualBasic/VisualBasicFormatter.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/VisualBasic/VisualBasicFormatter.cs
@@ -27,8 +27,8 @@ using dnSpy.Debugger.DotNet.Metadata;
 namespace dnSpy.Roslyn.Debugger.Formatters.VisualBasic {
 	[ExportDbgDotNetFormatter(DbgDotNetLanguageGuids.VisualBasic)]
 	sealed class VisualBasicFormatter : LanguageFormatter {
-		public override void FormatType(DbgEvaluationInfo evalInfo, IDbgTextWriter output, DmdType type, DbgDotNetValue? value, DbgValueFormatterTypeOptions options, CultureInfo? cultureInfo) =>
-			new VisualBasicTypeFormatter(output, options.ToTypeFormatterOptions(), cultureInfo).Format(type, value);
+		public override void FormatType(DbgEvaluationInfo evalInfo, IDbgTextWriter output, DmdType type, AdditionalTypeInfoState additionalTypeInfo, DbgDotNetValue? value, DbgValueFormatterTypeOptions options, CultureInfo? cultureInfo) =>
+			new VisualBasicTypeFormatter(output, options.ToTypeFormatterOptions(), cultureInfo).Format(type, additionalTypeInfo, value);
 
 		public override void FormatValue(DbgEvaluationInfo evalInfo, IDbgTextWriter output, DbgDotNetValue value, DbgValueFormatterOptions options, CultureInfo? cultureInfo) =>
 			new VisualBasicValueFormatter(output, evalInfo, this, options.ToValueFormatterOptions(), cultureInfo).Format(value);

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/VisualBasic/VisualBasicTypeFormatter.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/Formatters/VisualBasic/VisualBasicTypeFormatter.cs
@@ -124,10 +124,10 @@ namespace dnSpy.Roslyn.Debugger.Formatters.VisualBasic {
 
 		void WriteIdentifier(string? id, DbgTextColor color) => OutputWrite(GetFormattedIdentifier(id), color);
 
-		public void Format(DmdType type, DbgDotNetValue? value, IAdditionalTypeInfoProvider? additionalTypeInfoProvider = null) {
-			var state = new AdditionalTypeInfoState(additionalTypeInfoProvider);
-			FormatCore(type, value, ref state);
-		}
+		public void Format(DmdType type, DbgDotNetValue? value = null, IAdditionalTypeInfoProvider? additionalTypeInfoProvider = null) =>
+			Format(type,new AdditionalTypeInfoState(additionalTypeInfoProvider), value);
+
+		public void Format(DmdType type, AdditionalTypeInfoState state, DbgDotNetValue? value = null) => FormatCore(type, value, ref state);
 
 		void FormatCore(DmdType type, DbgDotNetValue? value, ref AdditionalTypeInfoState state) {
 			if (type is null)

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/GetLocalsAssemblyBuilder.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/GetLocalsAssemblyBuilder.cs
@@ -194,7 +194,14 @@ namespace dnSpy.Roslyn.Debugger {
 				if (dynamicAttr.ConstructorArguments.Count == 0)
 					dynamicFlags = new ReadOnlyCollection<byte>(new byte[] { 1 });
 				else if (dynamicAttr.ConstructorArguments.Count == 1 && dynamicAttr.ConstructorArguments[0].Value is IList<CAArgument> flags) {
-					int offset = parameter.Type.RemovePinnedAndModifiers().IsByRef ? 1 : 0;
+					int offset = 0;
+					var type = parameter.Type.RemovePinned();
+					while (type is ModifierSig) {
+						type = type.Next.RemovePinned();
+						offset++;
+					}
+					if (type.IsByRef)
+						offset++;
 					bool[]? array = new bool[flags.Count - offset];
 					for (var i = 0; i < array.Length; i++) {
 						var argValue = flags[i + offset].Value;

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/GetLocalsAssemblyBuilder.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/GetLocalsAssemblyBuilder.cs
@@ -194,9 +194,10 @@ namespace dnSpy.Roslyn.Debugger {
 				if (dynamicAttr.ConstructorArguments.Count == 0)
 					dynamicFlags = new ReadOnlyCollection<byte>(new byte[] { 1 });
 				else if (dynamicAttr.ConstructorArguments.Count == 1 && dynamicAttr.ConstructorArguments[0].Value is IList<CAArgument> flags) {
-					bool[]? array = new bool[flags.Count];
-					for (var i = 0; i < flags.Count; i++) {
-						var argValue = flags[i].Value;
+					int offset = parameter.Type.RemovePinnedAndModifiers().IsByRef ? 1 : 0;
+					bool[]? array = new bool[flags.Count - offset];
+					for (var i = 0; i < array.Length; i++) {
+						var argValue = flags[i + offset].Value;
 						if (argValue is bool b)
 							array[i] = b;
 						else {

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/StateWithKey.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/StateWithKey.cs
@@ -35,7 +35,7 @@ namespace dnSpy.Roslyn.Debugger {
 				var list = state.list;
 				for (int i = 0; i < list.Count; i++) {
 					var info = list[i];
-					if (info.key == key)
+					if (Equals(info.key, key))
 						return info.data;
 				}
 				return null;
@@ -50,7 +50,7 @@ namespace dnSpy.Roslyn.Debugger {
 				var list = state.list;
 				for (int i = 0; i < list.Count; i++) {
 					var info = list[i];
-					if (info.key == key)
+					if (Equals(info.key, key))
 						return info.data;
 				}
 				var data = create();

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/ArrayValueNodeProvider.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/ArrayValueNodeProvider.cs
@@ -27,6 +27,7 @@ using dnSpy.Contracts.Debugger.DotNet.Text;
 using dnSpy.Contracts.Debugger.Evaluation;
 using dnSpy.Contracts.Debugger.Text;
 using dnSpy.Debugger.DotNet.Metadata;
+using dnSpy.Roslyn.Debugger.Formatters;
 
 namespace dnSpy.Roslyn.Debugger.ValueNodes {
 	sealed class ArrayValueNodeProvider : DbgDotNetValueNodeProvider {
@@ -39,16 +40,19 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 		readonly DbgDotNetValueNodeProviderFactory owner;
 		readonly bool addParens;
 		readonly DmdType slotType;
+		readonly AdditionalTypeInfoState typeInfo;
 		readonly DbgDotNetValueNodeInfo valueInfo;
 		readonly uint arrayCount;
 		readonly DbgDotNetArrayDimensionInfo[] dimensionInfos;
 		// This one's only non-null if this is an array with 2 or more dimensions
 		readonly int[]? indexes;
 
-		public ArrayValueNodeProvider(DbgDotNetValueNodeProviderFactory owner, bool addParens, DmdType slotType, DbgDotNetValueNodeInfo valueInfo) {
+		public ArrayValueNodeProvider(DbgDotNetValueNodeProviderFactory owner, bool addParens, DmdType slotType, AdditionalTypeInfoState typeInfo, DbgDotNetValueNodeInfo valueInfo) {
 			this.owner = owner;
 			this.addParens = addParens;
 			this.slotType = slotType;
+			typeInfo.DynamicTypeIndex++;
+			this.typeInfo = typeInfo;
 			this.valueInfo = valueInfo;
 
 			bool b = valueInfo.Value.GetArrayInfo(out arrayCount, out dimensionInfos!) && dimensionInfos.Length != 0;
@@ -107,7 +111,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 							}
 						}
 						if (newNode is null)
-							newNode = valueNodeFactory.Create(evalInfo, name, newValue.Value, formatSpecifiers, options, expression, PredefinedDbgValueNodeImageNames.ArrayElement, false, false, elementType, false);
+							newNode = valueNodeFactory.Create(evalInfo, name, newValue.Value, formatSpecifiers, options, expression, PredefinedDbgValueNodeImageNames.ArrayElement, false, false, elementType, typeInfo, false);
 					}
 					newValue = default;
 					res[i] = newNode;

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/DbgDotNetValueNodeImpl.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/DbgDotNetValueNodeImpl.cs
@@ -51,8 +51,9 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 		readonly DbgDotNetText valueText;
 		ReadOnlyCollection<string>? formatSpecifiers;
 		readonly ColumnFormatter? columnFormatter;
+		readonly AdditionalTypeInfoState additionalTypeInfo;
 
-		public DbgDotNetValueNodeImpl(LanguageValueNodeFactory valueNodeFactory, DbgDotNetValueNodeProvider? childNodeProvider, DbgDotNetText name, DbgDotNetValueNodeInfo? nodeInfo, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType? expectedType, DmdType? actualType, string? errorMessage, DbgDotNetText valueText, ReadOnlyCollection<string>? formatSpecifiers, ColumnFormatter? columnFormatter) {
+		public DbgDotNetValueNodeImpl(LanguageValueNodeFactory valueNodeFactory, DbgDotNetValueNodeProvider? childNodeProvider, DbgDotNetText name, DbgDotNetValueNodeInfo? nodeInfo, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType? expectedType, AdditionalTypeInfoState additionalTypeInfo, DmdType? actualType, string? errorMessage, DbgDotNetText valueText, ReadOnlyCollection<string>? formatSpecifiers, ColumnFormatter? columnFormatter) {
 			if (name.Parts is null && columnFormatter is null)
 				throw new ArgumentException();
 			this.valueNodeFactory = valueNodeFactory ?? throw new ArgumentNullException(nameof(valueNodeFactory));
@@ -67,6 +68,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 			ExpectedType = expectedType;
 			ActualType = actualType;
 			ErrorMessage = errorMessage;
+			this.additionalTypeInfo = additionalTypeInfo;
 			this.valueText = valueText;
 			this.formatSpecifiers = formatSpecifiers;
 			this.columnFormatter = columnFormatter;
@@ -102,11 +104,13 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 
 		public override bool FormatActualType(DbgEvaluationInfo evalInfo, IDbgTextWriter output, DbgDotNetFormatter formatter, DbgValueFormatterTypeOptions options, DbgValueFormatterOptions valueOptions, CultureInfo? cultureInfo) =>
 			columnFormatter?.FormatActualType(evalInfo, output, formatter, options, valueOptions, cultureInfo) == true ||
-			FormatDebuggerDisplayAttributeType(evalInfo, output, formatter, valueOptions, cultureInfo);
+			FormatDebuggerDisplayAttributeType(evalInfo, output, formatter, valueOptions, cultureInfo) ||
+			FormatActualTypeLanguageFormatter(evalInfo, output, formatter, options, cultureInfo);
 
 		public override bool FormatExpectedType(DbgEvaluationInfo evalInfo, IDbgTextWriter output, DbgDotNetFormatter formatter, DbgValueFormatterTypeOptions options, DbgValueFormatterOptions valueOptions, CultureInfo? cultureInfo) =>
 			columnFormatter?.FormatExpectedType(evalInfo, output, formatter, options, valueOptions, cultureInfo) == true ||
-			FormatDebuggerDisplayAttributeType(evalInfo, output, formatter, valueOptions, cultureInfo);
+			FormatDebuggerDisplayAttributeType(evalInfo, output, formatter, valueOptions, cultureInfo) ||
+			FormatExpectedTypeLanguageFormatter(evalInfo, output, formatter, options, cultureInfo);
 
 		bool FormatDebuggerDisplayAttributeType(DbgEvaluationInfo evalInfo, IDbgTextWriter output, DbgDotNetFormatter formatter, DbgValueFormatterOptions options, CultureInfo? cultureInfo) {
 			if (Value is null)
@@ -119,6 +123,28 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 				return false;
 			var displayAttrFormatter = new DebuggerDisplayAttributeFormatter(evalInfo, languageFormatter, output, options, cultureInfo);
 			return displayAttrFormatter.FormatType(Value);
+		}
+
+		bool FormatActualTypeLanguageFormatter(DbgEvaluationInfo evalInfo, IDbgTextWriter output, DbgDotNetFormatter formatter, DbgValueFormatterTypeOptions options, CultureInfo? cultureInfo) {
+			if (formatter is not LanguageFormatter languageFormatter)
+				return false;
+			if (ActualType is null || ExpectedType is null)
+				return false;
+			if (ActualType != ExpectedType)
+				return false;
+
+			languageFormatter.FormatType(evalInfo, output, ActualType, additionalTypeInfo, Value, options, cultureInfo);
+			return true;
+		}
+
+		bool FormatExpectedTypeLanguageFormatter(DbgEvaluationInfo evalInfo, IDbgTextWriter output, DbgDotNetFormatter formatter, DbgValueFormatterTypeOptions options, CultureInfo? cultureInfo) {
+			if (formatter is not LanguageFormatter languageFormatter)
+				return false;
+			if (ExpectedType is null)
+				return false;
+
+			languageFormatter.FormatType(evalInfo, output, ExpectedType, additionalTypeInfo, Value, options, cultureInfo);
+			return true;
 		}
 
 		public override ulong GetChildCount(DbgEvaluationInfo evalInfo) =>

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/DbgDotNetValueNodeProviderFactory.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/DbgDotNetValueNodeProviderFactory.cs
@@ -28,6 +28,7 @@ using dnSpy.Contracts.Debugger.DotNet.Text;
 using dnSpy.Contracts.Debugger.Evaluation;
 using dnSpy.Contracts.Debugger.Text;
 using dnSpy.Debugger.DotNet.Metadata;
+using dnSpy.Roslyn.Debugger.Formatters;
 using dnSpy.Roslyn.Properties;
 
 namespace dnSpy.Roslyn.Debugger.ValueNodes {
@@ -42,6 +43,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 
 		sealed class TypeState {
 			public readonly DmdType Type;
+			public readonly AdditionalTypeInfoState AdditionalTypeInfo;
 			public readonly DmdType? EnumerableType;
 			public readonly TypeStateFlags Flags;
 			public readonly string TypeExpression;
@@ -64,8 +66,9 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 			public MemberValueNodeInfoCollection CachedRawViewInstanceMembers;
 			public MemberValueNodeInfoCollection CachedRawViewStaticMembers;
 
-			public TypeState(DmdType type, string typeExpression) {
+			public TypeState(DmdType type, string typeExpression, AdditionalTypeInfoState typeInfo) {
 				Type = type;
+				AdditionalTypeInfo = typeInfo;
 				Flags = TypeStateFlags.None;
 				TypeExpression = typeExpression;
 				HasNoChildren = true;
@@ -74,8 +77,9 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 				TupleFields = Array.Empty<TupleField>();
 			}
 
-			public TypeState(DmdType type, string typeExpression, MemberValueNodeInfoCollection instanceMembers, MemberValueNodeInfoCollection staticMembers, TupleField[] tupleFields) {
+			public TypeState(DmdType type, string typeExpression, AdditionalTypeInfoState typeInfo, MemberValueNodeInfoCollection instanceMembers, MemberValueNodeInfoCollection staticMembers, TupleField[] tupleFields) {
 				Type = type;
+				AdditionalTypeInfo = typeInfo;
 				EnumerableType = GetEnumerableType(type);
 				Flags = GetFlags(type, tupleFields);
 				TypeExpression = typeExpression;
@@ -200,14 +204,17 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 			NoExtraRawView	= 4,
 		}
 
-		public DbgDotNetValueNodeProviderResult Create(DbgEvaluationInfo evalInfo, bool addParens, DmdType slotType, DbgDotNetValueNodeInfo nodeInfo, DbgValueNodeEvaluationOptions options) {
+		public DbgDotNetValueNodeProviderResult Create(DbgEvaluationInfo evalInfo, bool addParens, DmdType slotType, DbgDotNetValueNodeInfo nodeInfo, DbgValueNodeEvaluationOptions options) =>
+			Create(evalInfo, addParens, slotType, default, nodeInfo, options);
+
+		public DbgDotNetValueNodeProviderResult Create(DbgEvaluationInfo evalInfo, bool addParens, DmdType slotType, AdditionalTypeInfoState typeInfoState, DbgDotNetValueNodeInfo nodeInfo, DbgValueNodeEvaluationOptions options) {
 			var providers = new List<DbgDotNetValueNodeProvider>(2);
-			Create(evalInfo, providers, addParens, slotType, nodeInfo, options, CreationOptions.None);
+			Create(evalInfo, providers, addParens, slotType, typeInfoState, nodeInfo, options, CreationOptions.None);
 			return new DbgDotNetValueNodeProviderResult(DbgDotNetValueNodeProvider.Create(providers));
 		}
 
 		public DbgDotNetValueNodeProviderResult CreateDynamicView(DbgEvaluationInfo evalInfo, bool addParens, DmdType slotType, DbgDotNetValueNodeInfo nodeInfo, DbgValueNodeEvaluationOptions options) {
-			var state = GetTypeState(nodeInfo);
+			var state = GetTypeState(nodeInfo, slotType, default);
 			var provider = TryCreateDynamicView(state, nodeInfo.Expression, addParens, nodeInfo.Value, slotType, options);
 			if (provider is not null)
 				return new DbgDotNetValueNodeProviderResult(provider);
@@ -215,32 +222,35 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 		}
 
 		public DbgDotNetValueNodeProviderResult CreateResultsView(DbgEvaluationInfo evalInfo, bool addParens, DmdType slotType, DbgDotNetValueNodeInfo nodeInfo, DbgValueNodeEvaluationOptions options) {
-			var state = GetTypeState(nodeInfo);
+			var state = GetTypeState(nodeInfo, slotType, default);
 			var provider = TryCreateResultsView(state, nodeInfo.Expression, addParens, nodeInfo.Value, slotType, options);
 			if (provider is not null)
 				return new DbgDotNetValueNodeProviderResult(provider);
 			return new DbgDotNetValueNodeProviderResult(dnSpy_Roslyn_Resources.ResultsView_MustBeEnumerableType);
 		}
 
-		TypeState GetTypeState(DbgDotNetValueNodeInfo nodeInfo) {
+		void Create(DbgEvaluationInfo evalInfo, List<DbgDotNetValueNodeProvider> providers, bool addParens, DmdType slotType, DbgDotNetValueNodeInfo nodeInfo, DbgValueNodeEvaluationOptions options, CreationOptions creationOptions) =>
+			CreateCore(evalInfo, providers, addParens, slotType, nodeInfo, GetTypeState(nodeInfo, slotType, default), options, creationOptions);
+
+		void Create(DbgEvaluationInfo evalInfo, List<DbgDotNetValueNodeProvider> providers, bool addParens, DmdType slotType, AdditionalTypeInfoState typeInfoState, DbgDotNetValueNodeInfo nodeInfo, DbgValueNodeEvaluationOptions options, CreationOptions creationOptions) =>
+			CreateCore(evalInfo, providers, addParens, slotType, nodeInfo, GetTypeState(nodeInfo, slotType, typeInfoState), options, creationOptions);
+
+		TypeState GetTypeState(DbgDotNetValueNodeInfo nodeInfo, DmdType slotType, AdditionalTypeInfoState typeInfoState) {
 			var type = nodeInfo.Value.Type;
 			if (type.IsByRef)
 				type = type.GetElementType()!;
-			return GetOrCreateTypeState(type);
+			return GetOrCreateTypeState(type, nodeInfo.Value.Type == slotType ? typeInfoState : default);
 		}
 
-		void Create(DbgEvaluationInfo evalInfo, List<DbgDotNetValueNodeProvider> providers, bool addParens, DmdType slotType, DbgDotNetValueNodeInfo nodeInfo, DbgValueNodeEvaluationOptions options, CreationOptions creationOptions) =>
-			CreateCore(evalInfo, providers, addParens, slotType, nodeInfo, GetTypeState(nodeInfo), options, creationOptions);
-
-		TypeState GetOrCreateTypeState(DmdType type) {
-			var state = StateWithKey<TypeState>.TryGet(type, this);
+		TypeState GetOrCreateTypeState(DmdType type, AdditionalTypeInfoState typeInfoState) {
+			var state = StateWithKey<TypeState>.TryGet(type, (this, typeInfoState));
 			if (state is not null)
 				return state;
-			return CreateTypeState(type);
+			return CreateTypeState(type, typeInfoState);
 
-			TypeState CreateTypeState(DmdType type2) {
-				var state2 = CreateTypeStateCore(type2);
-				return StateWithKey<TypeState>.GetOrCreate(type2, this, () => state2);
+			TypeState CreateTypeState(DmdType type2, AdditionalTypeInfoState typeInfoState2) {
+				var state2 = CreateTypeStateCore(type2, typeInfoState2);
+				return StateWithKey<TypeState>.GetOrCreate(type2, (this, typeInfoState2), () => state2);
 			}
 		}
 
@@ -278,7 +288,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 			return output.ToString();
 		}
 
-		TupleField[]? TryCreateTupleFields(DmdType type) {
+		TupleField[]? TryCreateTupleFields(DmdType type, AdditionalTypeInfoState typeInfoState) {
 			var tupleArity = Formatters.TypeFormatterUtils.GetTupleArity(type);
 			if (tupleArity <= 0)
 				return null;
@@ -288,24 +298,25 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 				if (info.tupleIndex < 0)
 					return null;
 				var defaultName = GetDefaultTupleName(info.tupleIndex);
-				tupleFields[info.tupleIndex] = new TupleField(defaultName, null, info.fields!.ToArray());
+				var customName = typeInfoState.TypeInfoProvider?.GetTupleElementName(typeInfoState.TupleNameIndex + info.tupleIndex);
+				tupleFields[info.tupleIndex] = new TupleField(defaultName, customName, info.fields!.ToArray());
 			}
 			return tupleFields;
 		}
 
 		static string GetDefaultTupleName(int tupleIndex) => "Item" + (tupleIndex + 1).ToString();
 
-		TypeState CreateTypeStateCore(DmdType type) {
+		TypeState CreateTypeStateCore(DmdType type, AdditionalTypeInfoState typeInfoState) {
 			var typeExpression = GetTypeExpression(type);
 			if (HasNoChildren(type) || type.IsFunctionPointer)
-				return new TypeState(type, typeExpression);
+				return new TypeState(type, typeExpression, typeInfoState);
 
 			MemberValueNodeInfoCollection instanceMembers, staticMembers;
 			TupleField[] tupleFields;
 
 			Debug.Assert(!type.IsByRef);
 			if (type.TypeSignatureKind == DmdTypeSignatureKind.Type || type.TypeSignatureKind == DmdTypeSignatureKind.GenericInstance) {
-				tupleFields = TryCreateTupleFields(type) ?? Array.Empty<TupleField>();
+				tupleFields = TryCreateTupleFields(type, typeInfoState) ?? Array.Empty<TupleField>();
 
 				var instanceMembersList = new List<MemberValueNodeInfo>();
 				var staticMembersList = new List<MemberValueNodeInfo>();
@@ -387,7 +398,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 				tupleFields = Array.Empty<TupleField>();
 			}
 
-			return new TypeState(type, typeExpression, instanceMembers, staticMembers, tupleFields);
+			return new TypeState(type, typeExpression, typeInfoState, instanceMembers, staticMembers, tupleFields);
 		}
 
 		MemberValueNodeInfo[] InitializeOverloadedMembers(MemberValueNodeInfo[] memberInfos) {
@@ -487,7 +498,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 					return false;
 
 				nodeInfo.SetDisplayValue(fieldValue.Value!);
-				Create(evalInfo, providers, addParens, slotType, nodeInfo, evalOptions, creationOptions | CreationOptions.NoNullable);
+				Create(evalInfo, providers, addParens, slotType, state.AdditionalTypeInfo, nodeInfo, evalOptions, creationOptions | CreationOptions.NoNullable);
 				disposeFieldValue = false;
 				return true;
 			}
@@ -516,7 +527,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 			bool funcEval = (evalOptions & DbgValueNodeEvaluationOptions.NoFuncEval) == 0;
 
 			if (state.IsTupleType && !forceRawView) {
-				providers.Add(new TupleValueNodeProvider(addParens, slotType, nodeInfo, state.TupleFields));
+				providers.Add(new TupleValueNodeProvider(addParens, slotType, state.AdditionalTypeInfo, nodeInfo, state.TupleFields));
 				AddProvidersOneChildNode(providers, state, nodeInfo.Expression, addParens, slotType, nodeInfo.Value, evalOptions, isRawView: true);
 				return;
 			}
@@ -571,7 +582,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 		}
 
 		internal void GetMemberCollections(DmdType type, DbgValueNodeEvaluationOptions evalOptions, out MemberValueNodeInfoCollection instanceMembersInfos, out MemberValueNodeInfoCollection staticMembersInfos) {
-			var state = GetOrCreateTypeState(type);
+			var state = GetOrCreateTypeState(type, default);
 			GetMemberCollections(state, evalOptions, out instanceMembersInfos, out staticMembersInfos);
 		}
 

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/DbgDotNetValueNodeProviderFactory.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/DbgDotNetValueNodeProviderFactory.cs
@@ -288,7 +288,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 				if (info.tupleIndex < 0)
 					return null;
 				var defaultName = GetDefaultTupleName(info.tupleIndex);
-				tupleFields[info.tupleIndex] = new TupleField(defaultName, info.fields!.ToArray());
+				tupleFields[info.tupleIndex] = new TupleField(defaultName, null, info.fields!.ToArray());
 			}
 			return tupleFields;
 		}

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/DbgDotNetValueNodeProviderFactory.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/DbgDotNetValueNodeProviderFactory.cs
@@ -519,7 +519,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 			}
 
 			if (state.Type.IsArray && !nodeInfo.Value.IsNull) {
-				providers.Add(new ArrayValueNodeProvider(this, addParens, slotType, nodeInfo));
+				providers.Add(new ArrayValueNodeProvider(this, addParens, slotType, state.AdditionalTypeInfo, nodeInfo));
 				return;
 			}
 
@@ -618,7 +618,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 			if (value.IsNull)
 				instanceMembersInfos = MemberValueNodeInfoCollection.Empty;
 			if (PointerValueNodeProvider.IsSupported(value))
-				providers.Add(new PointerValueNodeProvider(this, expression, value));
+				providers.Add(new PointerValueNodeProvider(this, expression, value, state.AdditionalTypeInfo));
 			else {
 				providers.Add(new InstanceMembersValueNodeProvider(valueNodeFactory, isRawView ? rawViewName : InstanceMembersName,
 					expression, addParens, slotType, value, instanceMembersInfos, membersEvalOptions,

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/LanguageValueNodeFactory.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/LanguageValueNodeFactory.cs
@@ -56,10 +56,10 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 		}
 
 		internal DbgDotNetValueNode Create(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValueNodeProvider provider, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, DbgDotNetText valueText) =>
-			new DbgDotNetValueNodeImpl(this, provider, name, null, expression, imageName, true, false, null, null, null, valueText, formatSpecifiers, null);
+			new DbgDotNetValueNodeImpl(this, provider, name, null, expression, imageName, true, false, null, default, null, null, valueText, formatSpecifiers, null);
 
 		internal DbgDotNetValueNode Create(DbgDotNetValueNodeProvider provider, DbgDotNetText name, DbgDotNetValueNodeInfo nodeInfo, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType, DmdType actualType, string? errorMessage, DbgDotNetText valueText, ReadOnlyCollection<string>? formatSpecifiers) =>
-			new DbgDotNetValueNodeImpl(this, provider, name, nodeInfo, expression, imageName, isReadOnly, causesSideEffects, expectedType, actualType, errorMessage, valueText, formatSpecifiers, null);
+			new DbgDotNetValueNodeImpl(this, provider, name, nodeInfo, expression, imageName, isReadOnly, causesSideEffects, expectedType, default, actualType, errorMessage, valueText, formatSpecifiers, null);
 
 		DbgDotNetValueNode CreateValue(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType, AdditionalTypeInfoState typeInfoState, bool isRootExpression, ColumnFormatter? columnFormatter) {
 			// Could be a by-ref property, local, or parameter.
@@ -93,11 +93,11 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 				info = valueNodeProviderFactory.Create(evalInfo, addParens, expectedType, typeInfoState, nodeInfo, options);
 			if (useProvider) {
 				if (info.ErrorMessage is not null)
-					return new DbgDotNetValueNodeImpl(this, info.Provider, name, nodeInfo, expression, PredefinedDbgValueNodeImageNames.Error, true, false, null, null, info.ErrorMessage, new DbgDotNetText(new DbgDotNetTextPart(DbgTextColor.Error, info.ErrorMessage)), formatSpecifiers, columnFormatter);
+					return new DbgDotNetValueNodeImpl(this, info.Provider, name, nodeInfo, expression, PredefinedDbgValueNodeImageNames.Error, true, false, null, default, null, info.ErrorMessage, new DbgDotNetText(new DbgDotNetTextPart(DbgTextColor.Error, info.ErrorMessage)), formatSpecifiers, columnFormatter);
 				Debug2.Assert(info.Provider is not null);
-				return new DbgDotNetValueNodeImpl(this, info.Provider, name, nodeInfo, expression, info.Provider?.ImageName ?? imageName, true, false, null, null, info.ErrorMessage, info.Provider?.ValueText ?? default, formatSpecifiers, columnFormatter);
+				return new DbgDotNetValueNodeImpl(this, info.Provider, name, nodeInfo, expression, info.Provider?.ImageName ?? imageName, true, false, null, default, null, info.ErrorMessage, info.Provider?.ValueText ?? default, formatSpecifiers, columnFormatter);
 			}
-			return new DbgDotNetValueNodeImpl(this, info.Provider, name, nodeInfo, expression, imageName, isReadOnly, causesSideEffects, expectedType, value.Type, info.ErrorMessage, default, formatSpecifiers, columnFormatter);
+			return new DbgDotNetValueNodeImpl(this, info.Provider, name, nodeInfo, expression, imageName, isReadOnly, causesSideEffects, expectedType, typeInfoState, value.Type, info.ErrorMessage, default, formatSpecifiers, columnFormatter);
 		}
 
 		public sealed override DbgDotNetValueNode Create(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType, DbgDotNetCustomTypeInfo? customTypeInfo) =>
@@ -177,7 +177,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 		protected abstract void FormatReturnValueMethodName(DbgEvaluationInfo evalInfo, IDbgTextWriter output, DbgValueFormatterTypeOptions typeOptions, DbgValueFormatterOptions valueOptions, CultureInfo? cultureInfo, DmdMethodBase method, DmdPropertyInfo? property);
 
 		public sealed override DbgDotNetValueNode CreateError(DbgEvaluationInfo evalInfo, DbgDotNetText name, string errorMessage, string expression, bool causesSideEffects) =>
-			new DbgDotNetValueNodeImpl(this, null, name, null, expression, PredefinedDbgValueNodeImageNames.Error, true, causesSideEffects, null, null, errorMessage, default, null, null);
+			new DbgDotNetValueNodeImpl(this, null, name, null, expression, PredefinedDbgValueNodeImageNames.Error, true, causesSideEffects, null, default, null, errorMessage, default, null, null);
 
 		public sealed override DbgDotNetValueNode CreateTypeVariables(DbgEvaluationInfo evalInfo, DbgDotNetTypeVariableInfo[] typeVariableInfos) =>
 			new DbgDotNetTypeVariablesNode(this, typeVariableInfos);

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/LanguageValueNodeFactory.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/LanguageValueNodeFactory.cs
@@ -28,6 +28,7 @@ using dnSpy.Contracts.Debugger.DotNet.Text;
 using dnSpy.Contracts.Debugger.Evaluation;
 using dnSpy.Contracts.Debugger.Text;
 using dnSpy.Debugger.DotNet.Metadata;
+using dnSpy.Roslyn.Debugger.Formatters;
 
 namespace dnSpy.Roslyn.Debugger.ValueNodes {
 	abstract class LanguageValueNodeFactory : DbgDotNetValueNodeFactory {
@@ -60,7 +61,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 		internal DbgDotNetValueNode Create(DbgDotNetValueNodeProvider provider, DbgDotNetText name, DbgDotNetValueNodeInfo nodeInfo, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType, DmdType actualType, string? errorMessage, DbgDotNetText valueText, ReadOnlyCollection<string>? formatSpecifiers) =>
 			new DbgDotNetValueNodeImpl(this, provider, name, nodeInfo, expression, imageName, isReadOnly, causesSideEffects, expectedType, actualType, errorMessage, valueText, formatSpecifiers, null);
 
-		DbgDotNetValueNode CreateValue(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType, bool isRootExpression, ColumnFormatter? columnFormatter) {
+		DbgDotNetValueNode CreateValue(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType, AdditionalTypeInfoState typeInfoState, bool isRootExpression, ColumnFormatter? columnFormatter) {
 			// Could be a by-ref property, local, or parameter.
 			if (expectedType.IsByRef) {
 				if (value.Type.IsByRef) {
@@ -71,6 +72,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 					value = newValue.Value!;
 				}
 				expectedType = expectedType.GetElementType()!;
+				typeInfoState.DynamicTypeIndex++;
 			}
 
 			options = PredefinedFormatSpecifiers.GetValueNodeEvaluationOptions(formatSpecifiers, options);
@@ -88,7 +90,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 				useProvider = true;
 			}
 			else
-				info = valueNodeProviderFactory.Create(evalInfo, addParens, expectedType, nodeInfo, options);
+				info = valueNodeProviderFactory.Create(evalInfo, addParens, expectedType, typeInfoState, nodeInfo, options);
 			if (useProvider) {
 				if (info.ErrorMessage is not null)
 					return new DbgDotNetValueNodeImpl(this, info.Provider, name, nodeInfo, expression, PredefinedDbgValueNodeImageNames.Error, true, false, null, null, info.ErrorMessage, new DbgDotNetText(new DbgDotNetTextPart(DbgTextColor.Error, info.ErrorMessage)), formatSpecifiers, columnFormatter);
@@ -98,11 +100,17 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 			return new DbgDotNetValueNodeImpl(this, info.Provider, name, nodeInfo, expression, imageName, isReadOnly, causesSideEffects, expectedType, value.Type, info.ErrorMessage, default, formatSpecifiers, columnFormatter);
 		}
 
-		public sealed override DbgDotNetValueNode Create(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType) =>
-			Create(evalInfo, name, value, formatSpecifiers, options, expression, imageName, isReadOnly, causesSideEffects, expectedType, true);
+		public sealed override DbgDotNetValueNode Create(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType, DbgDotNetCustomTypeInfo? customTypeInfo) =>
+			Create(evalInfo, name, value, formatSpecifiers, options, expression, imageName, isReadOnly, causesSideEffects, expectedType, CustomTypeInfoAdditionalTypeInfoProvider.TryCreate(customTypeInfo), true);
+
+		internal DbgDotNetValueNode Create(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType, IAdditionalTypeInfoProvider? typeInfoProvider, bool isRootExpression) =>
+			CreateValue(evalInfo, name, value, formatSpecifiers, options, expression, imageName, isReadOnly, causesSideEffects, expectedType, new AdditionalTypeInfoState(typeInfoProvider), isRootExpression, null);
+
+		internal DbgDotNetValueNode Create(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType, AdditionalTypeInfoState typeInfoState, bool isRootExpression) =>
+			CreateValue(evalInfo, name, value, formatSpecifiers, options, expression, imageName, isReadOnly, causesSideEffects, expectedType, typeInfoState, isRootExpression, null);
 
 		internal DbgDotNetValueNode Create(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType, bool isRootExpression) =>
-			CreateValue(evalInfo, name, value, formatSpecifiers, options, expression, imageName, isReadOnly, causesSideEffects, expectedType, isRootExpression, null);
+			CreateValue(evalInfo, name, value, formatSpecifiers, options, expression, imageName, isReadOnly, causesSideEffects, expectedType, default, isRootExpression, null);
 
 		public sealed override DbgDotNetValueNode CreateException(DbgEvaluationInfo evalInfo, uint id, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options) {
 			var output = ObjectCache.AllocDotNetTextOutput();
@@ -112,7 +120,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 			const bool isReadOnly = true;
 			const bool causesSideEffects = false;
 			const string imageName = PredefinedDbgValueNodeImageNames.Exception;
-			return CreateValue(evalInfo, name, value, formatSpecifiers, options, expression, imageName, isReadOnly, causesSideEffects, value.Type, false, null);
+			return Create(evalInfo, name, value, formatSpecifiers, options, expression, imageName, isReadOnly, causesSideEffects, value.Type, false);
 		}
 
 		public sealed override DbgDotNetValueNode CreateStowedException(DbgEvaluationInfo evalInfo, uint id, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options) {
@@ -123,7 +131,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 			const bool isReadOnly = true;
 			const bool causesSideEffects = false;
 			const string imageName = PredefinedDbgValueNodeImageNames.StowedException;
-			return CreateValue(evalInfo, name, value, formatSpecifiers, options, expression, imageName, isReadOnly, causesSideEffects, value.Type, false, null);
+			return Create(evalInfo, name, value, formatSpecifiers, options, expression, imageName, isReadOnly, causesSideEffects, value.Type, false);
 		}
 
 		public sealed override DbgDotNetValueNode CreateReturnValue(DbgEvaluationInfo evalInfo, uint id, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, DmdMethodBase method) {
@@ -135,8 +143,17 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 			const bool causesSideEffects = false;
 			var property = PropertyState.TryGetProperty(method);
 			var imageName = property is not null ? ImageNameUtils.GetImageName(property) : ImageNameUtils.GetImageName(method, SupportsModuleTypes);
-			var expectedType = method is DmdMethodInfo mi ? mi.ReturnType : value.Type;
-			return CreateValue(evalInfo, default, value, formatSpecifiers, options, expression, imageName, isReadOnly, causesSideEffects, expectedType, false, columnFormatter);
+			DmdType expectedType;
+			IAdditionalTypeInfoProvider? typeInfoProvider;
+			if (method is DmdMethodInfo mi) {
+				expectedType = mi.ReturnType;
+				typeInfoProvider = CustomAttributeAdditionalTypeInfoProvider.Create(mi.ReturnParameter);
+			}
+			else {
+				expectedType = value.Type;
+				typeInfoProvider = null;
+			}
+			return CreateValue(evalInfo, default, value, formatSpecifiers, options, expression, imageName, isReadOnly, causesSideEffects, expectedType, new AdditionalTypeInfoState(typeInfoProvider), false, columnFormatter);
 		}
 
 		internal void FormatReturnValueMethodName(DbgEvaluationInfo evalInfo, IDbgTextWriter output, DbgValueFormatterOptions options, CultureInfo? cultureInfo, DmdMethodBase method) =>

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/MembersValueNodeProvider.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/MembersValueNodeProvider.cs
@@ -31,6 +31,7 @@ using dnSpy.Contracts.Debugger.Engine.Evaluation;
 using dnSpy.Contracts.Debugger.Evaluation;
 using dnSpy.Contracts.Debugger.Text;
 using dnSpy.Debugger.DotNet.Metadata;
+using dnSpy.Roslyn.Debugger.Formatters;
 using dnSpy.Roslyn.Properties;
 
 namespace dnSpy.Roslyn.Debugger.ValueNodes {
@@ -215,8 +216,10 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 				}
 				else if (valueResult.ValueIsException)
 					newNode = valueNodeFactory.Create(evalInfo, info.Name, valueResult.Value!, formatSpecifiers, options, expression, PredefinedDbgValueNodeImageNames.Error, true, false, expectedType, false);
-				else
-					newNode = valueNodeFactory.Create(evalInfo, info.Name, valueResult.Value!, formatSpecifiers, options, expression, imageName, isReadOnly, false, expectedType, false);
+				else {
+					var customTypeInfoProvider = CustomAttributeAdditionalTypeInfoProvider.Create(info.Member);
+					newNode = valueNodeFactory.Create(evalInfo, info.Name, valueResult.Value!, formatSpecifiers, options, expression, imageName, isReadOnly, false, expectedType, customTypeInfoProvider, false);
+				}
 
 				valueResult = default;
 				return (newNode, canHide);

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/PointerValueNodeProvider.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/PointerValueNodeProvider.cs
@@ -25,6 +25,7 @@ using dnSpy.Contracts.Debugger.DotNet.Evaluation;
 using dnSpy.Contracts.Debugger.DotNet.Evaluation.ValueNodes;
 using dnSpy.Contracts.Debugger.DotNet.Text;
 using dnSpy.Contracts.Debugger.Evaluation;
+using dnSpy.Roslyn.Debugger.Formatters;
 
 namespace dnSpy.Roslyn.Debugger.ValueNodes {
 	sealed class PointerValueNodeProvider : DbgDotNetValueNodeProvider {
@@ -35,13 +36,16 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 
 		readonly DbgDotNetValueNodeProviderFactory valueNodeProviderFactory;
 		readonly DbgDotNetValue value;
+		readonly AdditionalTypeInfoState typeInfo;
 		DbgDotNetValue? derefValue;
 		bool initialized;
 
-		public PointerValueNodeProvider(DbgDotNetValueNodeProviderFactory valueNodeProviderFactory, string expression, DbgDotNetValue value) {
+		public PointerValueNodeProvider(DbgDotNetValueNodeProviderFactory valueNodeProviderFactory, string expression, DbgDotNetValue value, AdditionalTypeInfoState typeInfo) {
 			Debug.Assert(IsSupported(value));
 			this.valueNodeProviderFactory = valueNodeProviderFactory;
 			this.value = value;
+			typeInfo.DynamicTypeIndex++;
+			this.typeInfo = typeInfo;
 			Expression = expression;
 		}
 
@@ -64,7 +68,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 			var derefExpr = valueNodeProviderFactory.GetDereferenceExpression(Expression);
 			ref readonly var derefName = ref valueNodeProviderFactory.GetDereferencedName();
 			var nodeInfo = new DbgDotNetValueNodeInfo(derefValue, derefExpr);
-			var res = valueNodeProviderFactory.Create(evalInfo, true, derefValue.Type, nodeInfo, options);
+			var res = valueNodeProviderFactory.Create(evalInfo, true, derefValue.Type, typeInfo, nodeInfo, options);
 			DbgDotNetValueNode valueNode;
 			if (res.ErrorMessage is not null)
 				valueNode = valueNodeFactory.CreateError(evalInfo, DbgDotNetText.Empty, res.ErrorMessage, derefExpr, false);

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/StaticMembersValueNodeProvider.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/StaticMembersValueNodeProvider.cs
@@ -27,6 +27,7 @@ using dnSpy.Contracts.Debugger.Engine.Evaluation;
 using dnSpy.Contracts.Debugger.Evaluation;
 using dnSpy.Contracts.Debugger.Text;
 using dnSpy.Debugger.DotNet.Metadata;
+using dnSpy.Roslyn.Debugger.Formatters;
 
 namespace dnSpy.Roslyn.Debugger.ValueNodes {
 	sealed class StaticMembersValueNodeProvider : MembersValueNodeProvider {
@@ -92,8 +93,10 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 					newNode = valueNodeFactory.CreateError(evalInfo, info.Name, valueResult.ErrorMessage!, expression, false);
 				else if (valueResult.ValueIsException)
 					newNode = valueNodeFactory.Create(evalInfo, info.Name, valueResult.Value!, formatSpecifiers, options, expression, PredefinedDbgValueNodeImageNames.Error, true, false, expectedType, false);
-				else
-					newNode = valueNodeFactory.Create(evalInfo, info.Name, valueResult.Value!, formatSpecifiers, options, expression, imageName, isReadOnly, false, expectedType, false);
+				else {
+					var customTypeInfoProvider = CustomAttributeAdditionalTypeInfoProvider.Create(info.Member);
+					newNode = valueNodeFactory.Create(evalInfo, info.Name, valueResult.Value!, formatSpecifiers, options, expression, imageName, isReadOnly, false, expectedType, customTypeInfoProvider, false);
+				}
 
 				valueResult = default;
 				return (newNode, true);

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/TupleField.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/TupleField.cs
@@ -27,12 +27,18 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 		public readonly string DefaultName;
 
 		/// <summary>
+		/// User defined name, if any.
+		/// </summary>
+		public readonly string? CustomName;
+
+		/// <summary>
 		/// All fields that must be accessed in order to get the value shown in the UI, eg. Rest.Rest.Item3
 		/// </summary>
 		public readonly DmdFieldInfo[] Fields;
 
-		public TupleField(string defaultName, DmdFieldInfo[] fields) {
+		public TupleField(string defaultName, string? customName, DmdFieldInfo[] fields) {
 			DefaultName = defaultName;
+			CustomName = customName;
 			Fields = fields;
 		}
 	}

--- a/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/TupleValueNodeProvider.cs
+++ b/dnSpy/Roslyn/dnSpy.Roslyn/Debugger/ValueNodes/TupleValueNodeProvider.cs
@@ -89,7 +89,7 @@ namespace dnSpy.Roslyn.Debugger.ValueNodes {
 						valueResult = default;
 					}
 
-					var name = new DbgDotNetText(new DbgDotNetTextPart(DbgTextColor.InstanceField, info.DefaultName));
+					var name = new DbgDotNetText(new DbgDotNetTextPart(DbgTextColor.InstanceField, info.CustomName ?? info.DefaultName));
 					DbgDotNetValueNode newNode;
 					if (errorMessage is not null)
 						newNode = valueNodeFactory.CreateError(evalInfo, name, errorMessage, expression, false);

--- a/dnSpy/dnSpy.Contracts.Debugger.DotNet/Evaluation/ValueNodes/DbgDotNetValueNodeFactory.cs
+++ b/dnSpy/dnSpy.Contracts.Debugger.DotNet/Evaluation/ValueNodes/DbgDotNetValueNodeFactory.cs
@@ -43,8 +43,9 @@ namespace dnSpy.Contracts.Debugger.DotNet.Evaluation.ValueNodes {
 		/// <param name="isReadOnly">true if it's a read-only value</param>
 		/// <param name="causesSideEffects">true if the expression causes side effects</param>
 		/// <param name="expectedType">Expected type</param>
+		/// <param name="customTypeInfo">Custom type info</param>
 		/// <returns></returns>
-		public abstract DbgDotNetValueNode Create(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType);
+		public abstract DbgDotNetValueNode Create(DbgEvaluationInfo evalInfo, DbgDotNetText name, DbgDotNetValue value, ReadOnlyCollection<string>? formatSpecifiers, DbgValueNodeEvaluationOptions options, string expression, string imageName, bool isReadOnly, bool causesSideEffects, DmdType expectedType, DbgDotNetCustomTypeInfo? customTypeInfo);
 
 		/// <summary>
 		/// Creates an exception value node


### PR DESCRIPTION
Link to issue(s) this pull request covers:
N/A

### Problem
SSeveral tool windows belonging to the debugger component did not properly display types with associated custom type information which resulted in `dynamic` being displayed as `object`, tuple field names being unavailable, and native integer types displaying as `IntPtr`.

### Solution
Add support for displaying this information in the debugger value nodes tool windows including `Locals`, `Static Fields`, `Watch`, etc.

![image](https://github.com/dnSpyEx/dnSpy/assets/37494960/161f487d-a2fb-4ae3-b45c-ca54d690a8bb)
