### PR TITLE
Update to dnlib 4.1

### DIFF
--- a/DnSpyCommon.props
+++ b/DnSpyCommon.props
@@ -43,7 +43,7 @@
 
     <!-- Update app.config whenever some of these versions change (eg. dnlib version) -->
     <DiaSymReaderVersion>1.7.0</DiaSymReaderVersion>
-    <DnlibVersion>3.6.0</DnlibVersion>
+    <DnlibVersion>4.1.0</DnlibVersion>
     <IcedVersion>1.20.0</IcedVersion>
     <MSBuildNuGetVersion>17.1.0</MSBuildNuGetVersion>
     <MSDiagRuntimeVersion>1.1.142101</MSDiagRuntimeVersion>

--- a/Extensions/dnSpy.AsmEditor/Resources/ResourceCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Resources/ResourceCommands.cs
@@ -2038,7 +2038,8 @@ namespace dnSpy.AsmEditor.Resources {
 			var opts = data.CreateResourceElementOptions();
 			string? error;
 			try {
-				opts = new ResourceElementOptions(SerializedImageUtilities.Serialize(opts.Create()));
+				var format = ((BinaryResourceData)imgRsrcElNode.ResourceElement.ResourceData).Format;
+				opts = new ResourceElementOptions(SerializedImageUtilities.Serialize(opts.Create(), format));
 				error = imgRsrcElNode.CheckCanUpdateData(opts.Create());
 			}
 			catch (Exception ex) {

--- a/Extensions/dnSpy.AsmEditor/Resources/ResourceCommands.cs
+++ b/Extensions/dnSpy.AsmEditor/Resources/ResourceCommands.cs
@@ -766,7 +766,7 @@ namespace dnSpy.AsmEditor.Resources {
 				return;
 
 			var outStream = new MemoryStream();
-			ResourceWriter.Write(module, outStream, new ResourceElementSet());
+			ResourceWriter.Write(module, outStream, ResourceElementSet.CreateForResourceReader(module));
 			var er = new EmbeddedResource(data.Name, outStream.ToArray(), data.Attributes);
 			var treeView = appService.DocumentTreeView.TreeView;
 			var treeNodeGroup = appService.DocumentTreeView.DocumentTreeNodeGroups.GetGroup(DocumentTreeNodeGroupType.ResourceTreeNodeGroup);

--- a/Extensions/dnSpy.AsmEditor/Resources/ResourceElementVM.cs
+++ b/Extensions/dnSpy.AsmEditor/Resources/ResourceElementVM.cs
@@ -292,7 +292,7 @@ namespace dnSpy.AsmEditor.Resources {
 			case ResourceElementType.TimeSpan:	return new BuiltInResourceData((ResourceTypeCode)code, TimeSpanVM.Value);
 			case ResourceElementType.ByteArray: return new BuiltInResourceData((ResourceTypeCode)code, Data ?? Array.Empty<byte>());
 			case ResourceElementType.Stream:	return new BuiltInResourceData((ResourceTypeCode)code, Data ?? Array.Empty<byte>());
-			case ResourceElementType.SerializedType: return new BinaryResourceData(new UserResourceType(UserTypeVM.TypeFullName, ResourceTypeCode.UserTypes), UserTypeVM.GetSerializedData());
+			case ResourceElementType.SerializedType: return new BinaryResourceData(new UserResourceType(UserTypeVM.TypeFullName, ResourceTypeCode.UserTypes), UserTypeVM.GetSerializedData(), SerializationFormat.BinaryFormatter);
 			default: throw new InvalidOperationException();
 			}
 		}

--- a/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/Resources/SerializationUtilities.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/Resources/SerializationUtilities.cs
@@ -56,7 +56,7 @@ namespace dnSpy.Contracts.Documents.TreeView.Resources {
 			var userType = new UserResourceType(typeName, ResourceTypeCode.UserTypes);
 			var rsrcElem = new ResourceElement {
 				Name = Path.GetFileName(filename),
-				ResourceData = new BinaryResourceData(userType, serializedData),
+				ResourceData = new BinaryResourceData(userType, serializedData, SerializationFormat.BinaryFormatter),
 			};
 
 			return rsrcElem;

--- a/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/Resources/SerializedImageListStreamerUtilities.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/Resources/SerializedImageListStreamerUtilities.cs
@@ -93,7 +93,7 @@ namespace dnSpy.Contracts.Documents.TreeView.Resources {
 			var typeName = SystemWindowsFormsImageListStreamer.AssemblyQualifiedName;
 			return new ResourceElement {
 				Name = opts.Name,
-				ResourceData = new BinaryResourceData(new UserResourceType(typeName, ResourceTypeCode.UserTypes), SerializationUtilities.Serialize(obj)),
+				ResourceData = new BinaryResourceData(new UserResourceType(typeName, ResourceTypeCode.UserTypes), SerializationUtilities.Serialize(obj), SerializationFormat.BinaryFormatter),
 			};
 		}
 

--- a/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/Resources/SerializedImageUtilities.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/Resources/SerializedImageUtilities.cs
@@ -116,7 +116,7 @@ namespace dnSpy.Contracts.Documents.TreeView.Resources {
 
 			return new ResourceElement {
 				Name = resElem.Name,
-				ResourceData = new BinaryResourceData(new UserResourceType(typeName, ResourceTypeCode.UserTypes), SerializationUtilities.Serialize(obj)),
+				ResourceData = new BinaryResourceData(new UserResourceType(typeName, ResourceTypeCode.UserTypes), SerializationUtilities.Serialize(obj), SerializationFormat.BinaryFormatter),
 			};
 		}
 	}

--- a/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/Resources/SerializedImageUtilities.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/Resources/SerializedImageUtilities.cs
@@ -180,7 +180,10 @@ namespace dnSpy.Contracts.Documents.TreeView.Resources {
 			}
 			else if (format == SerializationFormat.TypeConverterByteArray) {
 				var converter = TypeDescriptor.GetConverter(obj.GetType());
-				serializedData = (byte[])converter.ConvertTo(obj, typeof(byte[]));
+				var byteArr = converter.ConvertTo(obj, typeof(byte[]));
+				if (byteArr is not byte[] d)
+					throw new InvalidOperationException("Failed to serialize image");
+				serializedData = d;
 			}
 			else if (format == SerializationFormat.ActivatorStream) {
 				using (var stream = new MemoryStream()) {
@@ -192,7 +195,7 @@ namespace dnSpy.Contracts.Documents.TreeView.Resources {
 				}
 			}
 			else
-				throw new ArgumentOutOfRangeException();
+				throw new ArgumentOutOfRangeException(nameof(format));
 
 			return new ResourceElement {
 				Name = resElem.Name,

--- a/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/Resources/SerializedResourceElementNode.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/Resources/SerializedResourceElementNode.cs
@@ -17,10 +17,13 @@
     along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
 using System.Threading;
 using dnlib.DotNet.Resources;
 using dnSpy.Contracts.Images;
@@ -91,16 +94,59 @@ namespace dnSpy.Contracts.Documents.TreeView.Resources {
 			if (!CanDeserialize)
 				return;
 
-			var serializedData = ((BinaryResourceData)ResourceElement.ResourceData).Data;
-			var formatter = new BinaryFormatter();
-			try {
+			var binaryResourceData = ((BinaryResourceData)ResourceElement.ResourceData);
+			var serializedData = binaryResourceData.Data;
+			if (binaryResourceData.Format == SerializationFormat.BinaryFormatter) {
+				var formatter = new BinaryFormatter();
+				try {
 #pragma warning disable SYSLIB0011
-				deserializedData = formatter.Deserialize(new MemoryStream(serializedData));
+					deserializedData = formatter.Deserialize(new MemoryStream(serializedData));
 #pragma warning restore SYSLIB0011
+				}
+				catch {
+					return;
+				}
 			}
-			catch {
-				return;
+			else if (binaryResourceData.Format == SerializationFormat.TypeConverterByteArray) {
+				try {
+					var type = Type.GetType(binaryResourceData.TypeName);
+					if (type is null)
+						return;
+					var converter = TypeDescriptor.GetConverter(type);
+					if (converter is null)
+						return;
+					deserializedData = converter.ConvertFrom(serializedData);
+				}
+				catch {
+					return;
+				}
 			}
+			else if (binaryResourceData.Format == SerializationFormat.TypeConverterString) {
+				try {
+					var type = Type.GetType(binaryResourceData.TypeName);
+					if (type is null)
+						return;
+					var converter = TypeDescriptor.GetConverter(type);
+					if (converter is null)
+						return;
+					deserializedData = converter.ConvertFromInvariantString(Encoding.UTF8.GetString(serializedData));
+				}
+				catch {
+					return;
+				}
+			}
+			else if (binaryResourceData.Format == SerializationFormat.ActivatorStream) {
+				try {
+					var type = Type.GetType(binaryResourceData.TypeName);
+					if (type is null)
+						return;
+					deserializedData = Activator.CreateInstance(type, new MemoryStream(serializedData));
+				}
+				catch {
+					return;
+				}
+			}
+
 			if (deserializedData is null)
 				return;
 

--- a/dnSpy/dnSpy.Decompiler/MSBuild/ResXResourceFileWriter.cs
+++ b/dnSpy/dnSpy.Decompiler/MSBuild/ResXResourceFileWriter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2023 ElektroKill
 
     This file is part of dnSpy
@@ -182,8 +182,19 @@ namespace dnSpy.Decompiler.MSBuild {
 					throw new ArgumentOutOfRangeException();
 				}
 			}
-			if (resourceData is BinaryResourceData binaryResourceData)
-				return new ResXResourceInfo(ToBase64WrappedString(binaryResourceData.Data), binaryResourceData.TypeName, ResXResourceWriter.BinSerializedObjectMimeType);
+			if (resourceData is BinaryResourceData binaryResourceData) {
+				switch (binaryResourceData.Format) {
+				case SerializationFormat.BinaryFormatter:
+					return new ResXResourceInfo(ToBase64WrappedString(binaryResourceData.Data), binaryResourceData.TypeName, ResXResourceWriter.BinSerializedObjectMimeType);
+				case SerializationFormat.TypeConverterByteArray:
+				case SerializationFormat.ActivatorStream:
+					// RESX does not have a way to represent creation of an object using Activator.CreateInstance,
+					// so we fallback to the same representation as data passed into TypeConverter.
+					return new ResXResourceInfo(ToBase64WrappedString(binaryResourceData.Data), binaryResourceData.TypeName, ResXResourceWriter.ByteArraySerializedObjectMimeType);
+				case SerializationFormat.TypeConverterString:
+					return new ResXResourceInfo(Encoding.UTF8.GetString(binaryResourceData.Data), binaryResourceData.TypeName);
+				}
+			}
 
 			throw new ArgumentOutOfRangeException();
 		}

--- a/dnSpy/dnSpy/Documents/TreeView/Resources/ResourceElementSetNodeImpl.cs
+++ b/dnSpy/dnSpy/Documents/TreeView/Resources/ResourceElementSetNodeImpl.cs
@@ -99,7 +99,7 @@ namespace dnSpy.Documents.TreeView.Resources {
 		void RegenerateEmbeddedResource(ModuleDef module) {
 			TreeNode.EnsureChildrenLoaded();
 			var outStream = new MemoryStream();
-			var resources = new ResourceElementSet();
+			var resources = resourceElementSet.Clone();
 			foreach (DocumentTreeNodeData child in TreeNode.DataChildren) {
 				var resourceElement = ResourceElementNode.GetResourceElement(child);
 				if (resourceElement is null)

--- a/dnSpy/dnSpy/Documents/TreeView/Resources/SerializedImageResourceElementNode.cs
+++ b/dnSpy/dnSpy/Documents/TreeView/Resources/SerializedImageResourceElementNode.cs
@@ -42,7 +42,7 @@ namespace dnSpy.Documents.TreeView.Resources {
 			if (serializedData is null)
 				return null;
 
-			if (SerializedImageUtilities.GetImageData(module, serializedData.TypeName, serializedData.Data, out var imageData))
+			if (SerializedImageUtilities.GetImageData(module, serializedData.TypeName, serializedData.Data, serializedData.Format, out var imageData))
 				return new SerializedImageResourceElementNodeImpl(treeNodeGroup, resourceElement, imageData);
 
 			return null;
@@ -94,7 +94,7 @@ namespace dnSpy.Documents.TreeView.Resources {
 				return res;
 
 			var binData = (BinaryResourceData)newResElem.ResourceData;
-			if (!SerializedImageUtilities.GetImageData(this.GetModule(), binData.TypeName, binData.Data, out var imageData))
+			if (!SerializedImageUtilities.GetImageData(this.GetModule(), binData.TypeName, binData.Data, binData.Format, out var imageData))
 				return dnSpy_Resources.NewDataIsNotAnImage;
 
 			try {
@@ -111,7 +111,7 @@ namespace dnSpy.Documents.TreeView.Resources {
 			base.UpdateData(newResElem);
 
 			var binData = (BinaryResourceData)newResElem.ResourceData;
-			SerializedImageUtilities.GetImageData(this.GetModule(), binData.TypeName, binData.Data, out var imageData);
+			SerializedImageUtilities.GetImageData(this.GetModule(), binData.TypeName, binData.Data, binData.Format, out var imageData);
 			Debug2.Assert(imageData is not null);
 			InitializeImageData(imageData);
 		}

--- a/dnSpy/dnSpy/app.config
+++ b/dnSpy/dnSpy/app.config
@@ -45,7 +45,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="dnlib" publicKeyToken="50e96378b6e77999" culture="neutral"/>
-				<bindingRedirect oldVersion="3.0.0.0-3.6.0.0" newVersion="3.6.0.0"/>
+				<bindingRedirect oldVersion="3.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="iced" publicKeyToken="5baba79f4264913b" culture="neutral"/>


### PR DESCRIPTION
Link to issue(s) this pull request covers:
N/A

### Problem
dnSpyEx was not using the latest dnlib version.

### Solution
Updated the library and adjust to changes.
Extended support for resource element sets and their serialized object formats.
