### PR TITLE
Fix some processes missing from "Attach to Process (Unity)"

### DIFF
--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/AttachToProcess/UnityPlayerAttachProgramOptionsProvider.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/AttachToProcess/UnityPlayerAttachProgramOptionsProvider.cs
@@ -92,7 +92,7 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.AttachToProcess {
 			}
 		}
 
-		static readonly Regex playerAnnounceStringRegex = new Regex(@"^\[IP\] (\S+) \[Port\] (\d+) \[Flags\] (-?\d+) \[Guid\] (\d+) \[EditorId\] (\d+) \[Version\] (\d+) \[Id\] ([^\(]+)\(([^\)]+)\)(:(\d+))? \[Debug\] (\d+)");
+		static readonly Regex playerAnnounceStringRegex = new Regex(@"^\[IP\] (\S+) \[Port\] (\d+) \[Flags\] (-?\d+) \[Guid\] (\d+) \[EditorId\] (\d+) \[Version\] (\d+) \[Id\] ([^\(]+)\((?:\d+,)?([^\)]+)\)(:(\d+))? \[Debug\] (\d+)");
 		bool TryParseUnityPlayerData(string s, [NotNullWhen(true)] out string? ipAddress, out ushort port, [NotNullWhen(true)] out string? playerId) {
 			ipAddress = null;
 			port = 0;


### PR DESCRIPTION
### Problem
When using "Debug -> Attach to Process (Unity)...", my Unity process is not shown. Here's a screenshot:

![image](https://github.com/dnSpyEx/dnSpy/assets/199935/657187b7-e038-4458-bc9f-307ac564a32b)

### Root cause
It seems that my Unity player data string has a slightly different format than dnSpy expects which causes its regex to fail on it.

In the debugger, I can see that my Unity process's player data string is:

```
[IP] 10.0.1.10 [Port] 55000 [Flags] 2 [Guid] 886973232 [EditorId] 0 [Version] 1048832 [Id] WindowsPlayer(2,Rigderns-PC) [Debug] 1 [PackageName] WindowsPlayer [ProjectName] <no name>
```

[`TryParseUnityPlayerData` bails here](https://github.com/dnSpyEx/dnSpy/blob/7c2a7862d5d95129eb7714e7560e33298404540c/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/AttachToProcess/UnityPlayerAttachProgramOptionsProvider.cs#L117-L118) because the value it parsed for `machine` doesn't match `Dns.GetHostName()`:
- `machine:           "2,Rigderns-PC"`
- `Dns.GetHostName(): "Rigderns-PC"`

### Solution
I updated the regex to account for the possibility of a number and comma preceding the machine name. I verified "machine" is parsed properly regardless of whether it is preceded by a number. Examples:
- For `WindowsPlayer(2,Rigderns-PC)`, "machine" is parsed as `Rigderns-PC`
- For `WindowsPlayer(Rigderns-PC)`, "machine" is parsed as `Rigderns-PC`

(If there's test infrastructure in place, let me know and I can add some tests for this.)

I also verified that my Unity process is now listed in the "Attach to Process (Unity)" window.