### PR TITLE
Add the Dotnet runtimes to the list of assemblies

### DIFF
--- a/dnSpy/dnSpy.Contracts.Logic/Utilities/DotNetPathProvider.cs
+++ b/dnSpy/dnSpy.Contracts.Logic/Utilities/DotNetPathProvider.cs
@@ -101,6 +101,12 @@ namespace dnSpy.Contracts.Utilities {
 		/// <summary>
 		/// Returns the .NET Core runtime assembly directories found on the system.
 		/// </summary>
+		/// <returns>.NET Core framework path info</returns>
+		public FrameworkPath[] GetSharedDotNetPaths() => netPathsShared.SelectMany(x => x.frameworkPaths).ToArray();
+
+		/// <summary>
+		/// Returns the .NET Core runtime assembly directories found on the system.
+		/// </summary>
 		/// <param name="version">Preferred .NET Core version</param>
 		/// <param name="bitness">Preferred bitness</param>
 		/// <returns>.NET Core runtime assembly directories, null if not found</returns>

--- a/dnSpy/dnSpy.Contracts.Logic/Utilities/FrameworkPath.cs
+++ b/dnSpy/dnSpy.Contracts.Logic/Utilities/FrameworkPath.cs
@@ -147,8 +147,8 @@ namespace dnSpy.Contracts.Utilities {
 		/// Constructor
 		/// </summary>
 		/// <param name="path">.NET Core assembly directories</param>
-		/// <param name="bitness">assembly bitness</param>
-		/// <param name="version">assembly version</param>
+		/// <param name="bitness">Assembly bitness</param>
+		/// <param name="version">Assembly version</param>
 		/// <exception cref="ArgumentNullException"><paramref name="path"/> is null</exception>
 		public FrameworkPath(string path, int bitness, FrameworkVersion version) {
 			Path = path ?? throw new ArgumentNullException(nameof(path));
@@ -181,10 +181,10 @@ namespace dnSpy.Contracts.Utilities {
 		/// <summary>
 		/// Constructor
 		/// </summary>
-		/// <param name="major">the major component</param>
-		/// <param name="minor">the minor component</param>
-		/// <param name="patch">the patch component</param>
-		/// <param name="extra">the extra component</param>
+		/// <param name="major">The major component</param>
+		/// <param name="minor">The minor component</param>
+		/// <param name="patch">The patch component</param>
+		/// <param name="extra">The extra component</param>
 		public FrameworkVersion(int major, int minor, int patch, string extra) {
 			Major = major;
 			Minor = minor;

--- a/dnSpy/dnSpy.Contracts.Logic/Utilities/FrameworkPath.cs
+++ b/dnSpy/dnSpy.Contracts.Logic/Utilities/FrameworkPath.cs
@@ -135,16 +135,16 @@ namespace dnSpy.Contracts.Utilities {
 		/// </summary>
 		public readonly string Path;
 		/// <summary>
-		/// assembly bitness
+		/// Assembly bitness
 		/// </summary>
 		public readonly int Bitness;
 		/// <summary>
-		/// assembly version
+		/// Assembly version
 		/// </summary>
 		public readonly FrameworkVersion Version;
 
 		/// <summary>
-		/// 
+		/// Constructor
 		/// </summary>
 		/// <param name="path">.NET Core assembly directories</param>
 		/// <param name="bitness">assembly bitness</param>
@@ -162,24 +162,24 @@ namespace dnSpy.Contracts.Utilities {
 	/// </summary>
 	public readonly struct FrameworkVersion : IComparable<FrameworkVersion>, IEquatable<FrameworkVersion> {
 		/// <summary>
-		/// the major component
+		/// The major component
 		/// </summary>
 		public readonly int Major;
 		/// <summary>
-		/// the minor component
+		/// The minor component
 		/// </summary>
 		public readonly int Minor;
 		/// <summary>
-		/// the patch component
+		/// The patch component
 		/// </summary>
 		public readonly int Patch;
 		/// <summary>
-		/// the extra component
+		/// The extra component
 		/// </summary>
 		public readonly string Extra;
 
 		/// <summary>
-		/// 
+		/// Constructor
 		/// </summary>
 		/// <param name="major">the major component</param>
 		/// <param name="minor">the minor component</param>

--- a/dnSpy/dnSpy.Contracts.Logic/Utilities/FrameworkPath.cs
+++ b/dnSpy/dnSpy.Contracts.Logic/Utilities/FrameworkPath.cs
@@ -192,14 +192,14 @@ namespace dnSpy.Contracts.Utilities {
 			Extra = extra;
 		}
 
-		///<inheritdoc/>
+		/// <inheritdoc/>
 		public override string ToString() {
 			if (Extra.Length == 0)
 				return $"{Major}.{Minor}.{Patch}";
 			return $"{Major}.{Minor}.{Patch}-{Extra}";
 		}
 
-		///<inheritdoc/>
+		/// <inheritdoc/>
 		public int CompareTo(FrameworkVersion other) {
 			int c = Major.CompareTo(other.Major);
 			if (c != 0)
@@ -223,17 +223,17 @@ namespace dnSpy.Contracts.Utilities {
 			return StringComparer.Ordinal.Compare(a, b);
 		}
 
-		///<inheritdoc/>
+		/// <inheritdoc/>
 		public bool Equals(FrameworkVersion other) =>
 			Major == other.Major &&
 			Minor == other.Minor &&
 			Patch == other.Patch &&
 			StringComparer.Ordinal.Equals(Extra, other.Extra);
 
-		///<inheritdoc/>
+		/// <inheritdoc/>
 		public override bool Equals(object? obj) => obj is FrameworkVersion other && Equals(other);
 
-		///<inheritdoc/>
+		/// <inheritdoc/>
 		public override int GetHashCode() => Major ^ Minor ^ Patch ^ StringComparer.Ordinal.GetHashCode(Extra ?? string.Empty);
 	}
 }

--- a/dnSpy/dnSpy.Contracts.Logic/Utilities/FrameworkPath.cs
+++ b/dnSpy/dnSpy.Contracts.Logic/Utilities/FrameworkPath.cs
@@ -31,10 +31,12 @@ namespace dnSpy.Contracts.Utilities {
 		public readonly FrameworkVersion Version;
 		public readonly Version SystemVersion;
 		public readonly bool IsReferencePath;
+		internal readonly FrameworkPath[] frameworkPaths;
 
 		string DebuggerPaths => string.Join(Path.PathSeparator.ToString(), Paths);
 
 		public FrameworkPaths(FrameworkPath[] paths, bool isRef) {
+			frameworkPaths = paths;
 			var firstPath = paths[0];
 #if DEBUG
 			for (int i = 1; i < paths.Length; i++) {
@@ -122,13 +124,32 @@ namespace dnSpy.Contracts.Utilities {
 		}
 	}
 
+	/// <summary>
+	/// .NET Core path info
+	/// </summary>
 	// It's a class since very few of these are created
 	[DebuggerDisplay("{Bitness,d}-bit {Version,nq} {Path,nq}")]
-	sealed class FrameworkPath {
+	public sealed class FrameworkPath {
+		/// <summary>
+		/// .NET Core assembly directories
+		/// </summary>
 		public readonly string Path;
+		/// <summary>
+		/// assembly bitness
+		/// </summary>
 		public readonly int Bitness;
+		/// <summary>
+		/// assembly version
+		/// </summary>
 		public readonly FrameworkVersion Version;
 
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="path">.NET Core assembly directories</param>
+		/// <param name="bitness">assembly bitness</param>
+		/// <param name="version">assembly version</param>
+		/// <exception cref="ArgumentNullException"><paramref name="path"/> is null</exception>
 		public FrameworkPath(string path, int bitness, FrameworkVersion version) {
 			Path = path ?? throw new ArgumentNullException(nameof(path));
 			Bitness = bitness;
@@ -136,12 +157,34 @@ namespace dnSpy.Contracts.Utilities {
 		}
 	}
 
-	readonly struct FrameworkVersion : IComparable<FrameworkVersion>, IEquatable<FrameworkVersion> {
+	/// <summary>
+	/// .NET Core version info
+	/// </summary>
+	public readonly struct FrameworkVersion : IComparable<FrameworkVersion>, IEquatable<FrameworkVersion> {
+		/// <summary>
+		/// the major component
+		/// </summary>
 		public readonly int Major;
+		/// <summary>
+		/// the minor component
+		/// </summary>
 		public readonly int Minor;
+		/// <summary>
+		/// the patch component
+		/// </summary>
 		public readonly int Patch;
+		/// <summary>
+		/// the extra component
+		/// </summary>
 		public readonly string Extra;
 
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="major">the major component</param>
+		/// <param name="minor">the minor component</param>
+		/// <param name="patch">the patch component</param>
+		/// <param name="extra">the extra component</param>
 		public FrameworkVersion(int major, int minor, int patch, string extra) {
 			Major = major;
 			Minor = minor;
@@ -149,12 +192,14 @@ namespace dnSpy.Contracts.Utilities {
 			Extra = extra;
 		}
 
+		///<inheritdoc/>
 		public override string ToString() {
 			if (Extra.Length == 0)
 				return $"{Major}.{Minor}.{Patch}";
 			return $"{Major}.{Minor}.{Patch}-{Extra}";
 		}
 
+		///<inheritdoc/>
 		public int CompareTo(FrameworkVersion other) {
 			int c = Major.CompareTo(other.Major);
 			if (c != 0)
@@ -178,13 +223,17 @@ namespace dnSpy.Contracts.Utilities {
 			return StringComparer.Ordinal.Compare(a, b);
 		}
 
+		///<inheritdoc/>
 		public bool Equals(FrameworkVersion other) =>
 			Major == other.Major &&
 			Minor == other.Minor &&
 			Patch == other.Patch &&
 			StringComparer.Ordinal.Equals(Extra, other.Extra);
 
+		///<inheritdoc/>
 		public override bool Equals(object? obj) => obj is FrameworkVersion other && Equals(other);
+
+		///<inheritdoc/>
 		public override int GetHashCode() => Major ^ Minor ^ Patch ^ StringComparer.Ordinal.GetHashCode(Extra ?? string.Empty);
 	}
 }

--- a/dnSpy/dnSpy/Documents/Tabs/DefaultDocumentList.cs
+++ b/dnSpy/dnSpy/Documents/Tabs/DefaultDocumentList.cs
@@ -82,23 +82,20 @@ namespace dnSpy.Documents.Tabs {
 			if (fileName[0] >= 'A' && fileName[0] <= 'Z') {
 				// Exclude native assemblies here
 				// Microsoft.NETCore.App
-				if (fileName.StartsWith("Microsoft.DiaSymReader.Native.")) {
+				if (fileName.StartsWith("Microsoft.DiaSymReader.Native.", StringComparison.Ordinal))
 					return false;
-				}
 
 				// Microsoft.WindowsDesktop.App
-				if (fileName.StartsWith("D3DCompiler_") || fileName.Equals("PenImc_cor3") || fileName.Equals("PresentationNative_cor3")) {
+				if (fileName.StartsWith("D3DCompiler_", StringComparison.Ordinal) || fileName.Equals("PenImc_cor3") || fileName.Equals("PresentationNative_cor3"))
 					return false;
-				}
 
 				return true;
 			}
-			else if(fileName[0] >= 'a' && fileName[0] <= 'z') {
+			if (fileName[0] >= 'a' && fileName[0] <= 'z') {
 				// Include managed assemblies here
 				// Microsoft.NETCore.App
-				if (fileName.Equals("mscorlib") || fileName.Equals("netstandard")) {
+				if (fileName.Equals("mscorlib") || fileName.Equals("netstandard"))
 					return true;
-				}
 
 				return false;
 			}

--- a/dnSpy/dnSpy/Documents/Tabs/DefaultDocumentList.cs
+++ b/dnSpy/dnSpy/Documents/Tabs/DefaultDocumentList.cs
@@ -20,7 +20,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -74,22 +73,20 @@ namespace dnSpy.Documents.Tabs {
 		}
 
 		static bool FilterFiles(string file) {
-
 			var fileName = Path.GetFileName(file);
 
-			if (fileName.Length == 0) {
+			if (fileName.Length == 0)
 				return false;
-			}
 
-			//The official managed assemblies in .NET Core almost always start with uppercase characters, which makes it easy for quick filtering.
+			// The official managed assemblies in .NET Core almost always start with uppercase characters, which makes it easy for quick filtering.
 			if (fileName[0] >= 'A' && fileName[0] <= 'Z') {
-				//Exclude native assemblies here
-				//Microsoft.NETCore.App
+				// Exclude native assemblies here
+				// Microsoft.NETCore.App
 				if (fileName.StartsWith("Microsoft.DiaSymReader.Native.")) {
 					return false;
 				}
 
-				//Microsoft.WindowsDesktop.App
+				// Microsoft.WindowsDesktop.App
 				if (fileName.StartsWith("D3DCompiler_") || fileName.Equals("PenImc_cor3") || fileName.Equals("PresentationNative_cor3")) {
 					return false;
 				}
@@ -97,8 +94,8 @@ namespace dnSpy.Documents.Tabs {
 				return true;
 			}
 			else if(fileName[0] >= 'a' && fileName[0] <= 'z') {
-				//Include managed assemblies here
-				//Microsoft.NETCore.App
+				// Include managed assemblies here
+				// Microsoft.NETCore.App
 				if (fileName.Equals("mscorlib") || fileName.Equals("netstandard")) {
 					return true;
 				}
@@ -107,21 +104,6 @@ namespace dnSpy.Documents.Tabs {
 			}
 
 			return true;
-		}
-
-		static bool TryGetRuntimeFolder([NotNullWhen(true)] out string path) {
-			path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), @"dotnet\shared");
-			if (Directory.Exists(path)) {
-				return true;
-			}
-
-			//The previous dotnet installation was in the x86 folder
-			path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), @"dotnet\shared");
-			if (Directory.Exists(path)) {
-				return true;
-			}
-
-			return false;
 		}
 	}
 


### PR DESCRIPTION
### Problem
In the assembly list, it has only contained content related to the .NET Framework for a long time. As .NET Core becomes increasingly popular, it's time to add the installed runtimes to the list.

### Solution
This is a relatively simple solution—scan the files and add them to the list.

![image](https://github.com/dnSpyEx/dnSpy/assets/26250460/24500ab9-a263-4b9d-a04f-50a38be493c2)

