### PR TITLE
Edit environment variables in when starting the debugging session

### DIFF
--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Dialogs/DebugProgram/DotNetCommonStartDebuggingOptionsPage.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Dialogs/DebugProgram/DotNetCommonStartDebuggingOptionsPage.cs
@@ -22,6 +22,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Windows.Input;
 using dnSpy.Contracts.Debugger;
+using dnSpy.Contracts.Debugger.Dialogs;
 using dnSpy.Contracts.Debugger.DotNet.CorDebug;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
 using dnSpy.Contracts.MVVM;
@@ -70,8 +71,24 @@ namespace dnSpy.Debugger.DotNet.CorDebug.Dialogs.DebugProgram {
 		}
 		string workingDirectory = string.Empty;
 
+		public string EnvironmentString {
+			get {
+				var sb = new System.Text.StringBuilder();
+				foreach (var kv in Environment.Environment) {
+					sb.Append(kv.Key);
+					sb.Append('=');
+					sb.Append(kv.Value);
+					sb.Append(';');
+				}
+				return sb.ToString();
+			}
+		}
+
+		public DbgEnvironment Environment { get; } = new DbgEnvironment();
+
 		public ICommand PickFilenameCommand => new RelayCommand(a => PickNewFilename());
 		public ICommand PickWorkingDirectoryCommand => new RelayCommand(a => PickNewWorkingDirectory());
+		public ICommand EditEnvironmentCommand => new RelayCommand(a => EditEnvironment());
 
 		public EnumListVM BreakProcessKindVM => breakProcessKindVM;
 		readonly EnumListVM breakProcessKindVM = new EnumListVM(BreakProcessKindsUtils.BreakProcessKindList);
@@ -96,10 +113,12 @@ namespace dnSpy.Debugger.DotNet.CorDebug.Dialogs.DebugProgram {
 
 		protected readonly IPickFilename pickFilename;
 		readonly IPickDirectory pickDirectory;
+		readonly IDbgEnvironmentEditorService environmentEditorService;
 
-		protected DotNetCommonStartDebuggingOptionsPage(IPickFilename pickFilename, IPickDirectory pickDirectory) {
+		protected DotNetCommonStartDebuggingOptionsPage(IPickFilename pickFilename, IPickDirectory pickDirectory, IDbgEnvironmentEditorService environmentEditorService) {
 			this.pickFilename = pickFilename ?? throw new ArgumentNullException(nameof(pickFilename));
 			this.pickDirectory = pickDirectory ?? throw new ArgumentNullException(nameof(pickDirectory));
+			this.environmentEditorService = environmentEditorService ?? throw new ArgumentNullException(nameof(environmentEditorService));
 		}
 
 		static string? GetPath(string file) {
@@ -126,6 +145,11 @@ namespace dnSpy.Debugger.DotNet.CorDebug.Dialogs.DebugProgram {
 			WorkingDirectory = newDir;
 		}
 
+		void EditEnvironment() {
+			if (environmentEditorService.ShowEditDialog(Environment))
+				OnPropertyChanged(nameof(EnvironmentString));
+		}
+
 		static string FilterBreakKind(string? breakKind) {
 			foreach (var info in BreakProcessKindsUtils.BreakProcessKindList) {
 				if (StringComparer.Ordinal.Equals(breakKind, (string)info.Value))
@@ -139,6 +163,8 @@ namespace dnSpy.Debugger.DotNet.CorDebug.Dialogs.DebugProgram {
 			CommandLine = options.CommandLine ?? string.Empty;
 			// Must be init'd after Filename since it also overwrites this property
 			WorkingDirectory = options.WorkingDirectory ?? string.Empty;
+			Environment.Clear();
+			Environment.AddRange(options.Environment.Environment);
 			BreakKind = FilterBreakKind(options.BreakKind);
 		}
 
@@ -151,6 +177,8 @@ namespace dnSpy.Debugger.DotNet.CorDebug.Dialogs.DebugProgram {
 			options.Filename = Filename;
 			options.CommandLine = CommandLine;
 			options.WorkingDirectory = WorkingDirectory;
+			options.Environment.Clear();
+			options.Environment.AddRange(Environment.Environment);
 			options.BreakKind = FilterBreakKind(BreakKind);
 			return options;
 		}

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Dialogs/DebugProgram/DotNetFrameworkStartDebuggingOptionsPage.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Dialogs/DebugProgram/DotNetFrameworkStartDebuggingOptionsPage.cs
@@ -21,7 +21,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using dnSpy.Contracts.App;
+using dnSpy.Contracts.Controls.ToolWindows;
 using dnSpy.Contracts.Debugger;
+using dnSpy.Contracts.Debugger.Dialogs;
 using dnSpy.Contracts.Debugger.DotNet.CorDebug;
 using dnSpy.Contracts.Debugger.StartDebugging;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
@@ -47,8 +50,8 @@ namespace dnSpy.Debugger.DotNet.CorDebug.Dialogs.DebugProgram {
 			return list.ToArray();
 		}
 
-		public DotNetFrameworkStartDebuggingOptionsPage(IPickFilename pickFilename, IPickDirectory pickDirectory)
-			: base(pickFilename, pickDirectory) {
+		public DotNetFrameworkStartDebuggingOptionsPage(IPickFilename pickFilename, IPickDirectory pickDirectory, IDbgEnvironmentEditorService environmentEditorService)
+			: base(pickFilename, pickDirectory, environmentEditorService) {
 		}
 
 		protected override void PickNewFilename() {

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Dialogs/DebugProgram/DotNetStartDebuggingOptionsPage.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Dialogs/DebugProgram/DotNetStartDebuggingOptionsPage.cs
@@ -20,7 +20,10 @@
 using System;
 using System.IO;
 using System.Windows.Input;
+using dnSpy.Contracts.App;
+using dnSpy.Contracts.Controls.ToolWindows;
 using dnSpy.Contracts.Debugger;
+using dnSpy.Contracts.Debugger.Dialogs;
 using dnSpy.Contracts.Debugger.DotNet.CorDebug;
 using dnSpy.Contracts.Debugger.StartDebugging;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
@@ -75,8 +78,8 @@ namespace dnSpy.Debugger.DotNet.CorDebug.Dialogs.DebugProgram {
 
 		public ICommand PickHostFilenameCommand => new RelayCommand(a => PickNewHostFilename(), a => CanPickNewHostFilename);
 
-		public DotNetStartDebuggingOptionsPage(IPickFilename pickFilename, IPickDirectory pickDirectory)
-			: base(pickFilename, pickDirectory) => ConnectionTimeout = new UInt32VM(a => UpdateIsValid(), useDecimal: true);
+		public DotNetStartDebuggingOptionsPage(IPickFilename pickFilename, IPickDirectory pickDirectory, IDbgEnvironmentEditorService environmentEditorService)
+			: base(pickFilename, pickDirectory, environmentEditorService) => ConnectionTimeout = new UInt32VM(a => UpdateIsValid(), useDecimal: true);
 
 		bool CanPickNewHostFilename => UseHost;
 

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Dialogs/DebugProgram/StartDebuggingOptionsPageProviderImpl.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Dialogs/DebugProgram/StartDebuggingOptionsPageProviderImpl.cs
@@ -19,24 +19,29 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using dnSpy.Contracts.App;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
 using dnSpy.Contracts.MVVM;
+using dnSpy.Contracts.Controls.ToolWindows;
+using dnSpy.Contracts.Debugger.Dialogs;
 
 namespace dnSpy.Debugger.DotNet.CorDebug.Dialogs.DebugProgram {
 	[Export(typeof(StartDebuggingOptionsPageProvider))]
 	sealed class StartDebuggingOptionsPageProviderImpl : StartDebuggingOptionsPageProvider {
 		readonly IPickFilename pickFilename;
 		readonly IPickDirectory pickDirectory;
+		readonly IDbgEnvironmentEditorService environmentEditorService;
 
 		[ImportingConstructor]
-		StartDebuggingOptionsPageProviderImpl(IPickFilename pickFilename, IPickDirectory pickDirectory) {
+		StartDebuggingOptionsPageProviderImpl(IPickFilename pickFilename, IPickDirectory pickDirectory, IDbgEnvironmentEditorService environmentEditorService) {
 			this.pickFilename = pickFilename;
 			this.pickDirectory = pickDirectory;
+			this.environmentEditorService = environmentEditorService;
 		}
 
 		public override IEnumerable<StartDebuggingOptionsPage> Create(StartDebuggingOptionsPageContext context) {
-			yield return new DotNetFrameworkStartDebuggingOptionsPage(pickFilename, pickDirectory);
-			yield return new DotNetStartDebuggingOptionsPage(pickFilename, pickDirectory);
+			yield return new DotNetFrameworkStartDebuggingOptionsPage(pickFilename, pickDirectory, environmentEditorService);
+			yield return new DotNetStartDebuggingOptionsPage(pickFilename, pickDirectory, environmentEditorService);
 		}
 	}
 }

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Properties/dnSpy.Debugger.DotNet.CorDebug.Resources.Designer.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Properties/dnSpy.Debugger.DotNet.CorDebug.Resources.Designer.cs
@@ -88,6 +88,15 @@ namespace dnSpy.Debugger.DotNet.CorDebug.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Environment.
+        /// </summary>
+        public static string DbgAsm_Environment {
+            get {
+                return ResourceManager.GetString("DbgAsm_Environment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to E_xecutable.
         /// </summary>
         public static string DbgAsm_Executable {

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Properties/dnSpy.Debugger.DotNet.CorDebug.Resources.resx
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Properties/dnSpy.Debugger.DotNet.CorDebug.Resources.resx
@@ -123,6 +123,9 @@
   <data name="DbgAsm_BreakAt" xml:space="preserve">
     <value>_Break at</value>
   </data>
+  <data name="DbgAsm_Environment" xml:space="preserve">
+    <value>Environment</value>
+  </data>
   <data name="DbgAsm_Host" xml:space="preserve">
     <value>_Host</value>
   </data>

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Themes/wpf.styles.templates.xaml
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Themes/wpf.styles.templates.xaml
@@ -29,6 +29,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
@@ -47,11 +48,15 @@
             <TextBox Grid.Row="2" Grid.Column="1" Margin="5 5 0 0" Name="cwdTextBox" Text="{Binding WorkingDirectory, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
             <Button Grid.Row="2" Grid.Column="2" Margin="5 5 0 0" Style="{StaticResource EllipsisButton}" Command="{Binding PickWorkingDirectoryCommand}" />
 
-            <Label Grid.Row="3" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_RuntimeVersion}" Target="{Binding ElementName=runtimeVersionComboBox}" />
-            <ComboBox Grid.Row="3" Grid.Column="1" Margin="5 5 0 0" HorizontalAlignment="Stretch" Name="runtimeVersionComboBox" ItemsSource="{Binding RuntimeVersionsVM.Items}" SelectedIndex="{Binding RuntimeVersionsVM.SelectedIndex}" VerticalContentAlignment="Center" />
+            <Label Grid.Row="3" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_Environment}" Target="{Binding ElementName=envTextBox}" />
+            <TextBox Grid.Row="3" Grid.Column="1" Margin="5 5 0 0" Name="envTextBox" Text="{Binding EnvironmentString, Mode=OneWay}" IsReadOnly="True" />
+            <Button Grid.Row="3" Grid.Column="2" Margin="5 5 0 0" Style="{StaticResource EllipsisButton}" Command="{Binding EditEnvironmentCommand}" />
 
-            <Label Grid.Row="4" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_BreakAt}" Target="{Binding ElementName=breakComboBox}" />
-            <ComboBox Grid.Row="4" Grid.Column="1" Margin="5 5 0 0" HorizontalAlignment="Stretch" Name="breakComboBox" DisplayMemberPath="Name" ItemsSource="{Binding BreakProcessKindVM.Items}" SelectedIndex="{Binding BreakProcessKindVM.SelectedIndex}" VerticalContentAlignment="Center" />
+            <Label Grid.Row="4" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_RuntimeVersion}" Target="{Binding ElementName=runtimeVersionComboBox}" />
+            <ComboBox Grid.Row="4" Grid.Column="1" Margin="5 5 0 0" HorizontalAlignment="Stretch" Name="runtimeVersionComboBox" ItemsSource="{Binding RuntimeVersionsVM.Items}" SelectedIndex="{Binding RuntimeVersionsVM.SelectedIndex}" VerticalContentAlignment="Center" />
+
+            <Label Grid.Row="5" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_BreakAt}" Target="{Binding ElementName=breakComboBox}" />
+            <ComboBox Grid.Row="5" Grid.Column="1" Margin="5 5 0 0" HorizontalAlignment="Stretch" Name="breakComboBox" DisplayMemberPath="Name" ItemsSource="{Binding BreakProcessKindVM.Items}" SelectedIndex="{Binding BreakProcessKindVM.SelectedIndex}" VerticalContentAlignment="Center" />
         </Grid>
     </DataTemplate>
 
@@ -66,6 +71,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
@@ -84,20 +90,24 @@
             <TextBox Grid.Row="2" Grid.Column="1" Margin="5 5 0 0" Name="cwdTextBox" Text="{Binding WorkingDirectory, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
             <Button Grid.Row="2" Grid.Column="2" Margin="5 5 0 0" Style="{StaticResource EllipsisButton}" Command="{Binding PickWorkingDirectoryCommand}" />
 
-            <CheckBox Grid.Row="3" Grid.ColumnSpan="2" Margin="5 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_UseHostExecutable}" IsChecked="{Binding UseHost}" />
+            <Label Grid.Row="3" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_Environment}" Target="{Binding ElementName=envTextBox}" />
+            <TextBox Grid.Row="3" Grid.Column="1" Margin="5 5 0 0" Name="envTextBox" Text="{Binding EnvironmentString, Mode=OneWay}" IsReadOnly="True" />
+            <Button Grid.Row="3" Grid.Column="2" Margin="5 5 0 0" Style="{StaticResource EllipsisButton}" Command="{Binding EditEnvironmentCommand}" />
 
-            <Label Grid.Row="4" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_Host}" Target="{Binding ElementName=hostTextBox}" />
-            <TextBox Grid.Row="4" Grid.Column="1" Margin="5 5 0 0" Name="hostTextBox" Text="{Binding HostFilename, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding UseHost}" />
-            <Button Grid.Row="4" Grid.Column="2" Margin="5 5 0 0" Style="{StaticResource EllipsisButton}" Command="{Binding PickHostFilenameCommand}" />
+            <CheckBox Grid.Row="4" Grid.ColumnSpan="2" Margin="5 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_UseHostExecutable}" IsChecked="{Binding UseHost}" />
 
-            <Label Grid.Row="5" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_HostArgs}" Target="{Binding ElementName=hostArgsTextBox}" />
-            <TextBox Grid.Row="5" Grid.Column="1" Margin="5 5 0 0" Name="hostArgsTextBox" Text="{Binding HostArguments, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding UseHost}" />
+            <Label Grid.Row="5" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_Host}" Target="{Binding ElementName=hostTextBox}" />
+            <TextBox Grid.Row="5" Grid.Column="1" Margin="5 5 0 0" Name="hostTextBox" Text="{Binding HostFilename, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding UseHost}" />
+            <Button Grid.Row="5" Grid.Column="2" Margin="5 5 0 0" Style="{StaticResource EllipsisButton}" Command="{Binding PickHostFilenameCommand}" />
 
-            <Label Grid.Row="6" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_Timeout}" Target="{Binding ElementName=timoutTextBox}" />
-            <TextBox Grid.Row="6" Grid.Column="1" Margin="5 5 0 0" Name="timoutTextBox" Text="{Binding ConnectionTimeout.StringValue, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
+            <Label Grid.Row="6" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_HostArgs}" Target="{Binding ElementName=hostArgsTextBox}" />
+            <TextBox Grid.Row="6" Grid.Column="1" Margin="5 5 0 0" Name="hostArgsTextBox" Text="{Binding HostArguments, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding UseHost}" />
 
-            <Label Grid.Row="7" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_BreakAt}" Target="{Binding ElementName=breakComboBox}" />
-            <ComboBox Grid.Row="7" Grid.Column="1" Margin="5 5 0 0" HorizontalAlignment="Stretch" Name="breakComboBox" DisplayMemberPath="Name" ItemsSource="{Binding BreakProcessKindVM.Items}" SelectedIndex="{Binding BreakProcessKindVM.SelectedIndex}" VerticalContentAlignment="Center" />
+            <Label Grid.Row="7" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_Timeout}" Target="{Binding ElementName=timoutTextBox}" />
+            <TextBox Grid.Row="7" Grid.Column="1" Margin="5 5 0 0" Name="timoutTextBox" Text="{Binding ConnectionTimeout.StringValue, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
+
+            <Label Grid.Row="8" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_CorDebug_Resources.DbgAsm_BreakAt}" Target="{Binding ElementName=breakComboBox}" />
+            <ComboBox Grid.Row="8" Grid.Column="1" Margin="5 5 0 0" HorizontalAlignment="Stretch" Name="breakComboBox" DisplayMemberPath="Name" ItemsSource="{Binding BreakProcessKindVM.Items}" SelectedIndex="{Binding BreakProcessKindVM.SelectedIndex}" VerticalContentAlignment="Center" />
         </Grid>
     </DataTemplate>
 

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/MonoStartDebuggingOptionsPage.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/MonoStartDebuggingOptionsPage.cs
@@ -21,6 +21,7 @@ using System;
 using System.IO;
 using System.Windows.Input;
 using dnSpy.Contracts.Debugger;
+using dnSpy.Contracts.Debugger.Dialogs;
 using dnSpy.Contracts.Debugger.DotNet.Mono;
 using dnSpy.Contracts.Debugger.StartDebugging;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
@@ -47,8 +48,8 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 
 		public ICommand PickMonoExePathCommand => new RelayCommand(a => PickMonoExePath());
 
-		public MonoStartDebuggingOptionsPage(IPickFilename pickFilename, IPickDirectory pickDirectory)
-			: base(pickFilename, pickDirectory) {
+		public MonoStartDebuggingOptionsPage(IPickFilename pickFilename, IPickDirectory pickDirectory, IDbgEnvironmentEditorService environmentEditorService)
+			: base(pickFilename, pickDirectory, environmentEditorService) {
 		}
 
 		static readonly string MonoExeFilter = $"mono.exe|mono.exe";

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/MonoStartDebuggingOptionsPageBase.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/MonoStartDebuggingOptionsPageBase.cs
@@ -22,6 +22,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Windows.Input;
 using dnSpy.Contracts.Debugger;
+using dnSpy.Contracts.Debugger.Dialogs;
 using dnSpy.Contracts.Debugger.DotNet.Mono;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
 using dnSpy.Contracts.MVVM;
@@ -70,6 +71,21 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 		}
 		string workingDirectory = string.Empty;
 
+		public string EnvironmentString {
+			get {
+				var sb = new System.Text.StringBuilder();
+				foreach (var kv in Environment.Environment) {
+					sb.Append(kv.Key);
+					sb.Append('=');
+					sb.Append(kv.Value);
+					sb.Append(';');
+				}
+				return sb.ToString();
+			}
+		}
+
+		public DbgEnvironment Environment { get; } = new DbgEnvironment();
+
 		public UInt16VM ConnectionPort { get; }
 		public UInt32VM ConnectionTimeout { get; }
 
@@ -83,6 +99,7 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 
 		public ICommand PickFilenameCommand => new RelayCommand(a => PickNewFilename());
 		public ICommand PickWorkingDirectoryCommand => new RelayCommand(a => PickNewWorkingDirectory());
+		public ICommand EditEnvironmentCommand => new RelayCommand(a => EditEnvironment());
 
 		public override bool IsValid => isValid;
 		bool isValid;
@@ -97,10 +114,12 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 
 		protected readonly IPickFilename pickFilename;
 		readonly IPickDirectory pickDirectory;
+		readonly IDbgEnvironmentEditorService environmentEditorService;
 
-		protected MonoStartDebuggingOptionsPageBase(IPickFilename pickFilename, IPickDirectory pickDirectory) {
+		protected MonoStartDebuggingOptionsPageBase(IPickFilename pickFilename, IPickDirectory pickDirectory, IDbgEnvironmentEditorService environmentEditorService) {
 			this.pickFilename = pickFilename ?? throw new ArgumentNullException(nameof(pickFilename));
 			this.pickDirectory = pickDirectory ?? throw new ArgumentNullException(nameof(pickDirectory));
+			this.environmentEditorService = environmentEditorService ?? throw new ArgumentNullException(nameof(environmentEditorService));
 			ConnectionPort = new UInt16VM(a => UpdateIsValid(), useDecimal: true);
 			ConnectionTimeout = new UInt32VM(a => UpdateIsValid(), useDecimal: true);
 		}
@@ -141,6 +160,11 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 				return;
 
 			WorkingDirectory = newDir;
+		}
+
+		void EditEnvironment() {
+			if (environmentEditorService.ShowEditDialog(Environment))
+				OnPropertyChanged(nameof(EnvironmentString));
 		}
 
 		protected void Initialize(MonoStartDebuggingOptionsBase options) {

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/MonoStartDebuggingOptionsPageBase.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/MonoStartDebuggingOptionsPageBase.cs
@@ -172,6 +172,8 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 			CommandLine = options.CommandLine ?? string.Empty;
 			// Must be init'd after Filename since it also overwrites this property
 			WorkingDirectory = options.WorkingDirectory ?? string.Empty;
+			Environment.Clear();
+			Environment.AddRange(options.Environment.Environment);
 			ConnectionPort.Value = options.ConnectionPort;
 			ConnectionTimeout.Value = (uint)options.ConnectionTimeout.TotalSeconds;
 			BreakKind = FilterBreakKind(options.BreakKind);
@@ -185,6 +187,8 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 			options.Filename = Filename;
 			options.CommandLine = CommandLine;
 			options.WorkingDirectory = WorkingDirectory;
+			options.Environment.Clear();
+			options.Environment.AddRange(Environment.Environment);
 			options.ConnectionPort = ConnectionPort.Value;
 			options.ConnectionTimeout = TimeSpan.FromSeconds(ConnectionTimeout.Value);
 			options.BreakKind = FilterBreakKind(BreakKind);

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/StartDebuggingOptionsPageProviderImpl.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/StartDebuggingOptionsPageProviderImpl.cs
@@ -19,6 +19,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using dnSpy.Contracts.Debugger.Dialogs;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
 using dnSpy.Contracts.MVVM;
 
@@ -27,19 +28,21 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 	sealed class StartDebuggingOptionsPageProviderImpl : StartDebuggingOptionsPageProvider {
 		readonly IPickFilename pickFilename;
 		readonly IPickDirectory pickDirectory;
+		readonly IDbgEnvironmentEditorService environmentEditorService;
 
 		[ImportingConstructor]
-		StartDebuggingOptionsPageProviderImpl(IPickFilename pickFilename, IPickDirectory pickDirectory) {
+		StartDebuggingOptionsPageProviderImpl(IPickFilename pickFilename, IPickDirectory pickDirectory, IDbgEnvironmentEditorService environmentEditorService) {
 			this.pickFilename = pickFilename;
 			this.pickDirectory = pickDirectory;
+			this.environmentEditorService = environmentEditorService;
 		}
 
 		public override IEnumerable<StartDebuggingOptionsPage> Create(StartDebuggingOptionsPageContext context) {
-			yield return new UnityStartDebuggingOptionsPage(pickFilename, pickDirectory);
+			yield return new UnityStartDebuggingOptionsPage(pickFilename, pickDirectory, environmentEditorService);
 			yield return new UnityConnectStartDebuggingOptionsPage();
 			// Disable mono support, see https://github.com/dnSpy/dnSpy/issues/643
 			// (Step Over doesn't work unless there's a portable PDB file available)
-			//yield return new MonoStartDebuggingOptionsPage(pickFilename, pickDirectory);
+			//yield return new MonoStartDebuggingOptionsPage(pickFilename, pickDirectory, environmentEditorService);
 			//yield return new MonoConnectStartDebuggingOptionsPage();
 		}
 	}

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/UnityStartDebuggingOptionsPage.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/UnityStartDebuggingOptionsPage.cs
@@ -21,6 +21,7 @@ using System;
 using System.IO;
 using System.Windows.Input;
 using dnSpy.Contracts.Debugger;
+using dnSpy.Contracts.Debugger.Dialogs;
 using dnSpy.Contracts.Debugger.DotNet.Mono;
 using dnSpy.Contracts.Debugger.StartDebugging;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
@@ -36,8 +37,8 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 		public ICommand DebuggingUnityGamesCommand => new RelayCommand(a => DebuggingUnityGamesHelper.OpenDebuggingUnityGames());
 		public string DebuggingUnityGamesText => DebuggingUnityGamesHelper.DebuggingUnityGamesText;
 
-		public UnityStartDebuggingOptionsPage(IPickFilename pickFilename, IPickDirectory pickDirectory)
-			: base(pickFilename, pickDirectory) {
+		public UnityStartDebuggingOptionsPage(IPickFilename pickFilename, IPickDirectory pickDirectory, IDbgEnvironmentEditorService environmentEditorService)
+			: base(pickFilename, pickDirectory, environmentEditorService) {
 		}
 
 		void Initialize(UnityStartDebuggingOptions options) {

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Impl/DbgEngineImpl.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Impl/DbgEngineImpl.cs
@@ -308,7 +308,6 @@ namespace dnSpy.Debugger.DotNet.Mono.Impl {
 						psi.RedirectStandardOutput = true;
 						psi.RedirectStandardError = true;
 					}
-					var env = new Dictionary<string, string>();
 					foreach (var kv in startMonoOptions.Environment.Environment)
 						psi.Environment[kv.Key] = kv.Value;
 					using (var process = Process.Start(psi)!) {
@@ -344,7 +343,6 @@ namespace dnSpy.Debugger.DotNet.Mono.Impl {
 						psi.RedirectStandardOutput = true;
 						psi.RedirectStandardError = true;
 					}
-					var env = new Dictionary<string, string>();
 					foreach (var kv in startUnityOptions.Environment.Environment)
 						psi.Environment[kv.Key] = kv.Value;
 

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Properties/dnSpy.Debugger.DotNet.Mono.Resources.Designer.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Properties/dnSpy.Debugger.DotNet.Mono.Resources.Designer.cs
@@ -159,6 +159,15 @@ namespace dnSpy.Debugger.DotNet.Mono.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Environment.
+        /// </summary>
+        public static string DbgAsm_Environment {
+            get {
+                return ResourceManager.GetString("DbgAsm_Environment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to E_xecutable.
         /// </summary>
         public static string DbgAsm_Executable {

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Properties/dnSpy.Debugger.DotNet.Mono.Resources.resx
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Properties/dnSpy.Debugger.DotNet.Mono.Resources.resx
@@ -132,6 +132,9 @@
   <data name="DbgAsm_Connect_To_Process" xml:space="preserve">
     <value>Connect</value>
   </data>
+  <data name="DbgAsm_Environment" xml:space="preserve">
+    <value>Environment</value>
+  </data>
   <data name="DbgAsm_IP_Address" xml:space="preserve">
     <value>IP Address</value>
   </data>

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Themes/wpf.styles.templates.xaml
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Themes/wpf.styles.templates.xaml
@@ -31,6 +31,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
@@ -49,15 +50,19 @@
             <TextBox Grid.Row="2" Grid.Column="1" Margin="5 5 0 0" Name="cwdTextBox" Text="{Binding WorkingDirectory, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
             <Button Grid.Row="2" Grid.Column="2" Margin="5 5 0 0" Style="{StaticResource EllipsisButton}" Command="{Binding PickWorkingDirectoryCommand}" />
 
-            <Label Grid.Row="3" Grid.Column="0" Margin="0 5 0 0" Content="_mono.exe" Target="{Binding ElementName=monoExeTextBox}" />
-            <TextBox Grid.Row="3" Grid.Column="1" Margin="5 5 0 0" Name="monoExeTextBox" Text="{Binding MonoExePath, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
-            <Button Grid.Row="3" Grid.Column="2" Margin="5 5 0 0" Style="{StaticResource EllipsisButton}" Command="{Binding PickMonoExePathCommand}" />
+            <Label Grid.Row="3" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_Mono_Resources.DbgAsm_Environment}" Target="{Binding ElementName=envTextBox}" />
+            <TextBox Grid.Row="3" Grid.Column="1" Margin="5 5 0 0" Name="envTextBox" Text="{Binding EnvironmentString, Mode=OneWay}" IsReadOnly="True" />
+            <Button Grid.Row="3" Grid.Column="2" Margin="5 5 0 0" Style="{StaticResource EllipsisButton}" Command="{Binding EditEnvironmentCommand}" />
 
-            <Label Grid.Row="4" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_Mono_Resources.DbgAsm_ConnectionPort}" Target="{Binding ElementName=portTextBox}" />
-            <TextBox Grid.Row="4" Grid.Column="1" Margin="5 5 0 0" Name="portTextBox" Text="{Binding ConnectionPort.StringValue, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
+            <Label Grid.Row="4" Grid.Column="0" Margin="0 5 0 0" Content="_mono.exe" Target="{Binding ElementName=monoExeTextBox}" />
+            <TextBox Grid.Row="4" Grid.Column="1" Margin="5 5 0 0" Name="monoExeTextBox" Text="{Binding MonoExePath, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
+            <Button Grid.Row="4" Grid.Column="2" Margin="5 5 0 0" Style="{StaticResource EllipsisButton}" Command="{Binding PickMonoExePathCommand}" />
 
-            <Label Grid.Row="5" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_Mono_Resources.DbgAsm_BreakAt}" Target="{Binding ElementName=breakComboBox}" />
-            <ComboBox Grid.Row="5" Grid.Column="1" Margin="5 5 0 0" HorizontalAlignment="Stretch" Name="breakComboBox" DisplayMemberPath="Name" ItemsSource="{Binding BreakProcessKindVM.Items}" SelectedIndex="{Binding BreakProcessKindVM.SelectedIndex}" VerticalContentAlignment="Center" />
+            <Label Grid.Row="5" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_Mono_Resources.DbgAsm_ConnectionPort}" Target="{Binding ElementName=portTextBox}" />
+            <TextBox Grid.Row="5" Grid.Column="1" Margin="5 5 0 0" Name="portTextBox" Text="{Binding ConnectionPort.StringValue, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
+
+            <Label Grid.Row="6" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_Mono_Resources.DbgAsm_BreakAt}" Target="{Binding ElementName=breakComboBox}" />
+            <ComboBox Grid.Row="6" Grid.Column="1" Margin="5 5 0 0" HorizontalAlignment="Stretch" Name="breakComboBox" DisplayMemberPath="Name" ItemsSource="{Binding BreakProcessKindVM.Items}" SelectedIndex="{Binding BreakProcessKindVM.SelectedIndex}" VerticalContentAlignment="Center" />
         </Grid>
     </DataTemplate>
 
@@ -99,6 +104,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
@@ -117,23 +123,27 @@
             <TextBox Grid.Row="2" Grid.Column="1" Margin="5 5 0 0" Name="cwdTextBox" Text="{Binding WorkingDirectory, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
             <Button Grid.Row="2" Grid.Column="2" Margin="5 5 0 0" Style="{StaticResource EllipsisButton}" Command="{Binding PickWorkingDirectoryCommand}" />
 
-            <Label Grid.Row="3" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_Mono_Resources.DbgAsm_ConnectionPort}" Target="{Binding ElementName=portTextBox}" />
-            <TextBox Grid.Row="3" Grid.Column="1" Margin="5 5 0 0" Name="portTextBox" Text="{Binding ConnectionPort.StringValue, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
+            <Label Grid.Row="3" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_Mono_Resources.DbgAsm_Environment}" Target="{Binding ElementName=envTextBox}" />
+            <TextBox Grid.Row="3" Grid.Column="1" Margin="5 5 0 0" Name="envTextBox" Text="{Binding EnvironmentString, Mode=OneWay}" IsReadOnly="True" />
+            <Button Grid.Row="3" Grid.Column="2" Margin="5 5 0 0" Style="{StaticResource EllipsisButton}" Command="{Binding EditEnvironmentCommand}" />
 
-            <Label Grid.Row="4" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_Mono_Resources.DbgAsm_ConnectionTimeoutInSeconds}" Target="{Binding ElementName=connectionTimeoutTextBox}" />
-            <TextBox Grid.Row="4" Grid.Column="1" Margin="5 5 0 0" Name="connectionTimeoutTextBox" Text="{Binding ConnectionTimeout.StringValue, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
+            <Label Grid.Row="4" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_Mono_Resources.DbgAsm_ConnectionPort}" Target="{Binding ElementName=portTextBox}" />
+            <TextBox Grid.Row="4" Grid.Column="1" Margin="5 5 0 0" Name="portTextBox" Text="{Binding ConnectionPort.StringValue, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
 
-            <StackPanel Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="5 5 0 0">
+            <Label Grid.Row="5" Grid.Column="0" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_DotNet_Mono_Resources.DbgAsm_ConnectionTimeoutInSeconds}" Target="{Binding ElementName=connectionTimeoutTextBox}" />
+            <TextBox Grid.Row="5" Grid.Column="1" Margin="5 5 0 0" Name="connectionTimeoutTextBox" Text="{Binding ConnectionTimeout.StringValue, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
+
+            <StackPanel Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="5 5 0 0">
                 <img:DsImage ImageReference="{x:Static img:DsImages.StatusWarning}"/>
                 <TextBlock Margin="5 0 0 0" Text="{x:Static p:dnSpy_Debugger_DotNet_Mono_Resources.CouldNotConnectToUnityGame_MakeSureMonoDllFileIsPatched}" />
             </StackPanel>
 
-            <StackPanel Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="5 5 0 0">
+            <StackPanel Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="5 5 0 0">
                 <img:DsImage ImageReference="{x:Static img:DsImages.StatusInformation}"/>
                 <TextBlock Margin="5 0 0 0" Text="{x:Static p:dnSpy_Debugger_DotNet_Mono_Resources.ConnectToUnity_UseAttachToUnityProcessDlgBoxMessage}" />
             </StackPanel>
 
-            <TextBlock Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="3" Margin="5 5 0 0"><Hyperlink Command="{Binding DebuggingUnityGamesCommand}"><Run Text="{Binding DebuggingUnityGamesText, Mode=OneWay}" /></Hyperlink></TextBlock>
+            <TextBlock Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="3" Margin="5 5 0 0"><Hyperlink Command="{Binding DebuggingUnityGamesCommand}"><Run Text="{Binding DebuggingUnityGamesText, Mode=OneWay}" /></Hyperlink></TextBlock>
         </Grid>
     </DataTemplate>
 

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/DbgEnvironmentEditorService.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/DbgEnvironmentEditorService.cs
@@ -1,0 +1,50 @@
+/*
+    Copyright (C) 2024 ElektroKill
+
+    This file is part of dnSpy
+
+    dnSpy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    dnSpy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System.ComponentModel.Composition;
+using dnSpy.Contracts.App;
+using dnSpy.Contracts.Controls.ToolWindows;
+using dnSpy.Contracts.Debugger;
+using dnSpy.Contracts.Debugger.Dialogs;
+
+namespace dnSpy.Debugger.Dialogs.EditEnvironment {
+	[Export(typeof(IDbgEnvironmentEditorService))]
+	class DbgEnvironmentEditorService : IDbgEnvironmentEditorService {
+		readonly IAppWindow appWindow;
+		readonly EditValueProviderService editValueProviderService;
+
+		[ImportingConstructor]
+		public DbgEnvironmentEditorService(IAppWindow appWindow, EditValueProviderService editValueProviderService) {
+			this.appWindow = appWindow;
+			this.editValueProviderService = editValueProviderService;
+		}
+
+		public bool ShowEditDialog(DbgEnvironment environment) {
+			var editEnvironment = new EditEnvironmentVM(editValueProviderService, environment);
+			var dlg = new EditEnvironmentDlg {
+				DataContext = editEnvironment,
+				Owner = appWindow.MainWindow
+			};
+			if (dlg.ShowDialog() != true)
+				return false;
+			editEnvironment.CopyTo(environment);
+			return true;
+		}
+	}
+}

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/EditEnvironmentDlg.xaml
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/EditEnvironmentDlg.xaml
@@ -1,0 +1,97 @@
+<!--
+    Copyright (C) 2024 ElektroKill
+
+    This file is part of dnSpy
+
+    dnSpy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    dnSpy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<winlocal:WindowBase x:Class="dnSpy.Debugger.Dialogs.EditEnvironment.EditEnvironmentDlg"
+                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                     xmlns:winlocal="clr-namespace:dnSpy.Contracts.Controls;assembly=dnSpy.Contracts.DnSpy"
+                     xmlns:mvvm="clr-namespace:dnSpy.Contracts.MVVM;assembly=dnSpy.Contracts.DnSpy"
+                     xmlns:mvvmvc="clr-namespace:dnSpy.Contracts.MVVM.Converters;assembly=dnSpy.Contracts.DnSpy"
+                     xmlns:img="clr-namespace:dnSpy.Contracts.Images;assembly=dnSpy.Contracts.DnSpy"
+                     xmlns:ui="clr-namespace:dnSpy.Contracts.Controls.ToolWindows;assembly=dnSpy.Contracts.DnSpy"
+                     xmlns:p="clr-namespace:dnSpy.Debugger.Properties"
+                     mc:Ignorable="d"
+                     Style="{StaticResource DialogWindowStyle}"
+                     Title="Edit environment variables" Height="350" Width="500"
+                     MinHeight="350" MinWidth="500"
+                     WindowStartupLocation="CenterOwner">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0" Margin="5 5 5 0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <ListView
+                Margin="5 5 5 0"
+                VirtualizingStackPanel.IsVirtualizing="True"
+                VirtualizingStackPanel.VirtualizationMode="Recycling"
+                mvvm:AutomationPeerMemoryLeakWorkaround.Initialize="True"
+                ui:ListBoxSelectedItemsAP.SelectedItemsVM="{Binding SelectedItems}"
+                SelectionMode="Extended"
+                ItemsSource="{Binding EnvironmentVariables}">
+                <ListView.View>
+                    <GridView>
+                        <GridViewColumn Header="Key">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <ui:EditValueControl ReadOnlyContent="{Binding Key}" EditableValue="{Binding KeyEditableValue}" EditValueProvider="{Binding KeyEditValueProvider}" />
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                        <GridViewColumn Header="Value">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <ui:EditValueControl ReadOnlyContent="{Binding Value}" EditableValue="{Binding ValueEditableValue}" EditValueProvider="{Binding ValueEditValueProvider}" />
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                    </GridView>
+                </ListView.View>
+            </ListView>
+
+            <Grid Grid.Column="1">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Button Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_Resources.AddEnvironmentVariableButton}" Style="{StaticResource DialogButton}" Command="{Binding AddEnvironmentVariableCommand}" />
+                <Button Grid.Row="1" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_Resources.RemoveEnvironmentVariableButton}" Style="{StaticResource DialogButton}" Command="{Binding RemoveEnvironmentVariableCommand}" />
+                <Button Grid.Row="2" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_Resources.ResetEnvironmentVariablesButton}" Style="{StaticResource DialogButton}" Command="{Binding ResetCommand}" />
+            </Grid>
+        </Grid>
+
+        <Grid Grid.Row="1" Margin="5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Button Grid.Column="1" Content="{x:Static p:dnSpy_Debugger_Resources.Button_OK}" IsDefault="True" Style="{StaticResource DialogButton}" Margin="0 0 5 0" Click="okButton_Click" />
+            <Button Grid.Column="2" Content="{x:Static p:dnSpy_Debugger_Resources.Button_Cancel}" IsCancel="True" Style="{StaticResource DialogButton}" />
+        </Grid>
+    </Grid>
+</winlocal:WindowBase>

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/EditEnvironmentDlg.xaml
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/EditEnvironmentDlg.xaml
@@ -23,13 +23,11 @@
                      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                      xmlns:winlocal="clr-namespace:dnSpy.Contracts.Controls;assembly=dnSpy.Contracts.DnSpy"
                      xmlns:mvvm="clr-namespace:dnSpy.Contracts.MVVM;assembly=dnSpy.Contracts.DnSpy"
-                     xmlns:mvvmvc="clr-namespace:dnSpy.Contracts.MVVM.Converters;assembly=dnSpy.Contracts.DnSpy"
-                     xmlns:img="clr-namespace:dnSpy.Contracts.Images;assembly=dnSpy.Contracts.DnSpy"
                      xmlns:ui="clr-namespace:dnSpy.Contracts.Controls.ToolWindows;assembly=dnSpy.Contracts.DnSpy"
                      xmlns:p="clr-namespace:dnSpy.Debugger.Properties"
                      mc:Ignorable="d"
                      Style="{StaticResource DialogWindowStyle}"
-                     Title="Edit environment variables" Height="350" Width="500"
+                     Title="{x:Static p:dnSpy_Debugger_Resources.EditEnvironmentVariables_Title}" Height="350" Width="500"
                      MinHeight="350" MinWidth="500"
                      WindowStartupLocation="CenterOwner">
     <Grid>
@@ -44,6 +42,7 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <ListView
+                Name="listView"
                 Margin="5 5 5 0"
                 VirtualizingStackPanel.IsVirtualizing="True"
                 VirtualizingStackPanel.VirtualizationMode="Recycling"
@@ -76,11 +75,13 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
                 <Button Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_Resources.AddEnvironmentVariableButton}" Style="{StaticResource DialogButton}" Command="{Binding AddEnvironmentVariableCommand}" />
-                <Button Grid.Row="1" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_Resources.RemoveEnvironmentVariableButton}" Style="{StaticResource DialogButton}" Command="{Binding RemoveEnvironmentVariableCommand}" />
-                <Button Grid.Row="2" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_Resources.ResetEnvironmentVariablesButton}" Style="{StaticResource DialogButton}" Command="{Binding ResetCommand}" />
+                <Button Grid.Row="1" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_Resources.AddManyEnvironmentVariablesButton}" Style="{StaticResource DialogButton}"  Command="{Binding AddManyEnvironmentVariablesCommand}"/>
+                <Button Grid.Row="2" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_Resources.RemoveEnvironmentVariableButton}" Style="{StaticResource DialogButton}" Command="{Binding RemoveEnvironmentVariableCommand}" />
+                <Button Grid.Row="3" Margin="0 5 0 0" Content="{x:Static p:dnSpy_Debugger_Resources.ResetEnvironmentVariablesButton}" Style="{StaticResource DialogButton}" Command="{Binding ResetCommand}" />
             </Grid>
         </Grid>
 

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/EditEnvironmentDlg.xaml.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/EditEnvironmentDlg.xaml.cs
@@ -1,0 +1,28 @@
+/*
+    Copyright (C) 2024 ElektroKill
+
+    This file is part of dnSpy
+
+    dnSpy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    dnSpy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using dnSpy.Contracts.Controls;
+
+namespace dnSpy.Debugger.Dialogs.EditEnvironment {
+	public partial class EditEnvironmentDlg : WindowBase {
+		public EditEnvironmentDlg() {
+			InitializeComponent();
+		}
+	}
+}

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/EditEnvironmentDlg.xaml.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/EditEnvironmentDlg.xaml.cs
@@ -23,6 +23,12 @@ namespace dnSpy.Debugger.Dialogs.EditEnvironment {
 	public partial class EditEnvironmentDlg : WindowBase {
 		public EditEnvironmentDlg() {
 			InitializeComponent();
+			listView.SelectionChanged += (_, e) => {
+				if (e.AddedItems.Count > 0)
+					listView.ScrollIntoView(e.AddedItems[e.AddedItems.Count - 1]);
+				else if (listView.SelectedItems.Count > 0)
+					listView.ScrollIntoView(listView.SelectedItems[listView.SelectedItems.Count - 1]);
+			};
 		}
 	}
 }

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/EditEnvironmentVM.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/EditEnvironmentVM.cs
@@ -1,0 +1,94 @@
+/*
+    Copyright (C) 2024 ElektroKill
+
+    This file is part of dnSpy
+
+    dnSpy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    dnSpy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using dnSpy.Contracts.Controls.ToolWindows;
+using dnSpy.Contracts.Debugger;
+using dnSpy.Contracts.MVVM;
+using dnSpy.Contracts.Text;
+
+namespace dnSpy.Debugger.Dialogs.EditEnvironment {
+	sealed class EditEnvironmentVM : ViewModelBase {
+		readonly EditValueProviderService editValueProviderService;
+		readonly DbgEnvironment originalEnvironment;
+
+		public ObservableCollection<EnvironmentVariableVM> EnvironmentVariables { get; }
+		public ObservableCollection<EnvironmentVariableVM> SelectedItems { get; }
+
+		IEditValueProvider KeyEditValueProvider => keyEditValueProvider ?? (keyEditValueProvider = editValueProviderService.Create(ContentTypes.EnvironmentVariableKey, Array.Empty<string>()));
+		IEditValueProvider? keyEditValueProvider;
+		IEditValueProvider ValueEditValueProvider => valueEditValueProvider ?? (valueEditValueProvider = editValueProviderService.Create(ContentTypes.EnvironmentVariableValue, Array.Empty<string>()));
+		IEditValueProvider? valueEditValueProvider;
+
+		public ICommand AddEnvironmentVariableCommand => new RelayCommand(a => AddEnvironmentVariable());
+		public ICommand RemoveEnvironmentVariableCommand => new RelayCommand(a => RemoveEnvironmentVariable(), a => SelectedItems.Count > 0);
+		public ICommand ResetCommand => new RelayCommand(a => Reset());
+
+		public EditEnvironmentVM(EditValueProviderService editValueProviderService) : this(editValueProviderService, new DbgEnvironment()) { }
+
+		public EditEnvironmentVM(EditValueProviderService editValueProviderService, DbgEnvironment environment) {
+			this.editValueProviderService = editValueProviderService;
+			originalEnvironment = environment;
+
+			EnvironmentVariables = new ObservableCollection<EnvironmentVariableVM>();
+			SelectedItems = new ObservableCollection<EnvironmentVariableVM>();
+
+			InitializeFrom(environment);
+		}
+
+		void AddEnvironmentVariable() {
+			SelectedItems.Clear();
+			var vm = new EnvironmentVariableVM(KeyEditValueProvider, ValueEditValueProvider);
+			EnvironmentVariables.Insert(0, vm);
+			SelectedItems.Add(vm);
+		}
+
+		void RemoveEnvironmentVariable() {
+			var itemsToRemove = new List<EnvironmentVariableVM>(SelectedItems);
+			SelectedItems.Clear();
+			foreach (var environmentVariableVm in itemsToRemove)
+				EnvironmentVariables.Remove(environmentVariableVm);
+		}
+
+		void Reset() {
+			SelectedItems.Clear();
+			EnvironmentVariables.Clear();
+			InitializeFrom(originalEnvironment);
+		}
+
+		void InitializeFrom(DbgEnvironment environment) {
+			foreach (var pair in environment.Environment) {
+				EnvironmentVariables.Add(new EnvironmentVariableVM(KeyEditValueProvider, ValueEditValueProvider) {
+					Key = pair.Key,
+					Value = pair.Value
+				});
+			}
+		}
+
+		public void CopyTo(DbgEnvironment environment) {
+			environment.Clear();
+			foreach (var environmentVariableVm in EnvironmentVariables)
+				environment.Add(environmentVariableVm.Key, environmentVariableVm.Value);
+		}
+	}
+}

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/EnvironmentStringParser.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/EnvironmentStringParser.cs
@@ -1,0 +1,114 @@
+/*
+    Copyright (C) 2024 ElektroKill
+
+    This file is part of dnSpy
+
+    dnSpy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    dnSpy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System.Collections.Generic;
+
+namespace dnSpy.Debugger.Dialogs.EditEnvironment {
+	public struct EnvironmentStringParser {
+		readonly string str;
+		int pos;
+
+		public EnvironmentStringParser(string str) => this.str = str;
+
+		public bool TryParse(out Dictionary<string, string> env) {
+			env = new Dictionary<string, string>();
+
+			for (;;) {
+				var key = GetNextToken();
+				if (key.Kind == TokenKind.EOF)
+					break;
+				if (key.Kind != TokenKind.String)
+					return false;
+				var assign = GetNextToken();
+				if (assign.Kind != TokenKind.Assign)
+					return false;
+				var value = GetNextToken();
+				if (value.Kind != TokenKind.String)
+					return false;
+
+				env[key.Value] = value.Value;
+
+				var seperator = GetNextToken();
+				if (seperator.Kind == TokenKind.EOF)
+					break;
+				if (seperator.Kind != TokenKind.Separator)
+					return false;
+			}
+
+			return true;
+		}
+
+		Token GetNextToken() {
+			if (pos >= str.Length)
+				return new Token(TokenKind.EOF);
+
+			var currentChar = str[pos++];
+			if (currentChar == ';')
+				return new Token(TokenKind.Separator);
+			if (currentChar == '=')
+				return new Token(TokenKind.Assign);
+
+			if (currentChar == '"') {
+				int stringStartPos = pos;
+				while (true) {
+					if (pos >= str.Length)
+						return new Token(TokenKind.Invalid);
+					if (str[pos++] == '"')
+						break;
+				}
+				if (pos == stringStartPos)
+					return new Token(TokenKind.Invalid);
+				return new Token(TokenKind.String, str.Substring(stringStartPos, pos - stringStartPos - 1));
+			}
+
+			int startPos = pos - 1;
+			while (true) {
+				if (pos >= str.Length || str[pos] is ';' or '=')
+					break;
+				pos++;
+			}
+			return new Token(TokenKind.String, str.Substring(startPos, pos - startPos));
+		}
+
+		enum TokenKind {
+			Invalid,
+			Separator,
+			Assign,
+			String,
+			EOF,
+		}
+
+		readonly struct Token {
+			public readonly TokenKind Kind;
+			public readonly string Value;
+
+			public Token(TokenKind kind) {
+				Kind = kind;
+				Value = string.Empty;
+			}
+
+			public Token(TokenKind kind, string value) {
+				Kind = kind;
+				Value = value;
+			}
+
+			public override string ToString() => Kind == TokenKind.String ? Value : Kind.ToString();
+		}
+	}
+}

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/EnvironmentVariableVM.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/EditEnvironment/EnvironmentVariableVM.cs
@@ -1,0 +1,62 @@
+/*
+    Copyright (C) 2024 ElektroKill
+
+    This file is part of dnSpy
+
+    dnSpy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    dnSpy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System;
+using dnSpy.Contracts.Controls.ToolWindows;
+using dnSpy.Contracts.MVVM;
+
+namespace dnSpy.Debugger.Dialogs.EditEnvironment {
+	sealed class EnvironmentVariableVM : ViewModelBase {
+		public string Key {
+			get => key;
+			set {
+				if (key != value) {
+					key = value;
+					OnPropertyChanged(nameof(Key));
+				}
+			}
+		}
+		string key = string.Empty;
+
+		public string Value {
+			get => value;
+			set {
+				if (this.value != value) {
+					this.value = value;
+					OnPropertyChanged(nameof(Value));
+				}
+			}
+		}
+		string value = string.Empty;
+
+		public IEditableValue KeyEditableValue { get; }
+		public IEditValueProvider KeyEditValueProvider { get; }
+		public IEditableValue ValueEditableValue { get; }
+		public IEditValueProvider ValueEditValueProvider { get; }
+
+		public EnvironmentVariableVM(IEditValueProvider keyEditValueProvider, IEditValueProvider valueEditValueProvider) {
+			KeyEditValueProvider = keyEditValueProvider;
+			KeyEditableValue = new EditableValueImpl(() => Key, s => Key = ConvertEditedString(s));
+			ValueEditValueProvider = valueEditValueProvider;
+			ValueEditableValue = new EditableValueImpl(() => Value, s => Value = ConvertEditedString(s));
+		}
+
+		static string ConvertEditedString(string? s) => string2.IsNullOrWhiteSpace(s) ? string.Empty : s.Trim();
+	}
+}

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/Properties/dnSpy.Debugger.Resources.Designer.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/Properties/dnSpy.Debugger.Resources.Designer.cs
@@ -71,6 +71,15 @@ namespace dnSpy.Debugger.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Add.
         /// </summary>
+        public static string AddEnvironmentVariableButton {
+            get {
+                return ResourceManager.GetString("AddEnvironmentVariableButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add.
+        /// </summary>
         public static string AddExceptionButton {
             get {
                 return ResourceManager.GetString("AddExceptionButton", resourceCulture);
@@ -2919,6 +2928,15 @@ namespace dnSpy.Debugger.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove.
+        /// </summary>
+        public static string RemoveEnvironmentVariableButton {
+            get {
+                return ResourceManager.GetString("RemoveEnvironmentVariableButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Remove.
         /// </summary>
         public static string RemoveExceptionCommand {
@@ -2942,6 +2960,15 @@ namespace dnSpy.Debugger.Properties {
         public static string ResetBreakpointHitCountCommand {
             get {
                 return ResourceManager.GetString("ResetBreakpointHitCountCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reset.
+        /// </summary>
+        public static string ResetEnvironmentVariablesButton {
+            get {
+                return ResourceManager.GetString("ResetEnvironmentVariablesButton", resourceCulture);
             }
         }
         

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/Properties/dnSpy.Debugger.Resources.Designer.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/Properties/dnSpy.Debugger.Resources.Designer.cs
@@ -78,6 +78,24 @@ namespace dnSpy.Debugger.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Environment.
+        /// </summary>
+        public static string AddEnvironmentVariablesMsgBoxLabel {
+            get {
+                return ResourceManager.GetString("AddEnvironmentVariablesMsgBoxLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add Environment Variables.
+        /// </summary>
+        public static string AddEnvironmentVariablesMsgBoxTitle {
+            get {
+                return ResourceManager.GetString("AddEnvironmentVariablesMsgBoxTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add.
         /// </summary>
         public static string AddExceptionButton {
@@ -92,6 +110,15 @@ namespace dnSpy.Debugger.Properties {
         public static string AddExceptionCommand {
             get {
                 return ResourceManager.GetString("AddExceptionCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add Many.
+        /// </summary>
+        public static string AddManyEnvironmentVariablesButton {
+            get {
+                return ResourceManager.GetString("AddManyEnvironmentVariablesButton", resourceCulture);
             }
         }
         
@@ -1842,6 +1869,15 @@ namespace dnSpy.Debugger.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Edit Environment Variables.
+        /// </summary>
+        public static string EditEnvironmentVariables_Title {
+            get {
+                return ResourceManager.GetString("EditEnvironmentVariables_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Edit Labels.
         /// </summary>
         public static string EditLabelsCommand {
@@ -2390,6 +2426,15 @@ namespace dnSpy.Debugger.Properties {
         public static string InternalDebuggerError {
             get {
                 return ResourceManager.GetString("InternalDebuggerError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid Input String.
+        /// </summary>
+        public static string InvalidInputString {
+            get {
+                return ResourceManager.GetString("InvalidInputString", resourceCulture);
             }
         }
         

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/Properties/dnSpy.Debugger.Resources.resx
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/Properties/dnSpy.Debugger.Resources.resx
@@ -951,6 +951,9 @@ Are you sure you want to expand it?</value>
   <data name="AddExceptionButton" xml:space="preserve">
     <value>Add</value>
   </data>
+  <data name="AddEnvironmentVariableButton" xml:space="preserve">
+    <value>Add</value>
+  </data>
   <data name="ExceptionDescription" xml:space="preserve">
     <value>Exception description</value>
   </data>
@@ -992,6 +995,9 @@ Are you sure you want to expand it?</value>
   </data>
   <data name="RemoveBreakpointCommand" xml:space="preserve">
     <value>Remove Breakpoint</value>
+  </data>
+  <data name="RemoveEnvironmentVariableButton" xml:space="preserve">
+    <value>Remove</value>
   </data>
   <data name="DisableBreakpointCommand3" xml:space="preserve">
     <value>Disable Breakpoint</value>
@@ -1304,6 +1310,9 @@ Do you wish to continue?</value>
   </data>
   <data name="ResetBreakpointHitCountCommand" xml:space="preserve">
     <value>Reset Hit Count</value>
+  </data>
+  <data name="ResetEnvironmentVariablesButton" xml:space="preserve">
+    <value>Reset</value>
   </data>
   <data name="HelpToolTip" xml:space="preserve">
     <value>Help</value>

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/Properties/dnSpy.Debugger.Resources.resx
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/Properties/dnSpy.Debugger.Resources.resx
@@ -954,6 +954,15 @@ Are you sure you want to expand it?</value>
   <data name="AddEnvironmentVariableButton" xml:space="preserve">
     <value>Add</value>
   </data>
+  <data name="AddEnvironmentVariablesMsgBoxTitle" xml:space="preserve">
+    <value>Add Environment Variables</value>
+  </data>
+  <data name="AddEnvironmentVariablesMsgBoxLabel" xml:space="preserve">
+    <value>Environment</value>
+  </data>
+  <data name="AddManyEnvironmentVariablesButton" xml:space="preserve">
+    <value>Add Many</value>
+  </data>
   <data name="ExceptionDescription" xml:space="preserve">
     <value>Exception description</value>
   </data>
@@ -962,6 +971,9 @@ Are you sure you want to expand it?</value>
   </data>
   <data name="EditConditions_Title" xml:space="preserve">
     <value>Edit Conditions</value>
+  </data>
+  <data name="EditEnvironmentVariables_Title" xml:space="preserve">
+    <value>Edit Environment Variables</value>
   </data>
   <data name="Button_AddCondition" xml:space="preserve">
     <value>_Add Condition</value>
@@ -1343,6 +1355,9 @@ Do you wish to continue?</value>
   </data>
   <data name="InsertTracepointCommand" xml:space="preserve">
     <value>Insert _Tracepoint</value>
+  </data>
+  <data name="InvalidInputString" xml:space="preserve">
+    <value>Invalid Input String</value>
   </data>
   <data name="UnwindToThisFrameCommand" xml:space="preserve">
     <value>_Unwind To This Frame</value>

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/UI/ContentTypeDefinitions.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/UI/ContentTypeDefinitions.cs
@@ -118,6 +118,16 @@ namespace dnSpy.Debugger.UI {
 		[Name(ContentTypes.ThreadsWindowName)]
 		[BaseDefinition(ContentTypes.Text)]
 		static readonly ContentTypeDefinition? ThreadsWindowName;
+
+		[Export]
+		[Name(ContentTypes.EnvironmentVariableKey)]
+		[BaseDefinition(ContentTypes.Text)]
+		static readonly ContentTypeDefinition? EnvironmentVariableKey;
+
+		[Export]
+		[Name(ContentTypes.EnvironmentVariableValue)]
+		[BaseDefinition(ContentTypes.Text)]
+		static readonly ContentTypeDefinition? EnvironmentVariableValue;
 #pragma warning restore CS0169
 	}
 }

--- a/Extensions/dnSpy.Scripting.Roslyn/Common/ScriptGlobals.cs
+++ b/Extensions/dnSpy.Scripting.Roslyn/Common/ScriptGlobals.cs
@@ -113,7 +113,7 @@ namespace dnSpy.Scripting.Roslyn.Common {
 
 		public MsgBoxButton ShowYNC(string message, Window? ownerWindow = null) => ShowYesNoCancel(message, ownerWindow);
 
-		public T Ask<T>(string labelMessage, string? defaultText = null, string? title = null, Func<string, T>? converter = null, Func<string, string>? verifier = null, Window? ownerWindow = null) =>
+		public T? Ask<T>(string labelMessage, string? defaultText = null, string? title = null, Func<string, T>? converter = null, Func<string, string>? verifier = null, Window? ownerWindow = null) =>
 			dispatcher.UI(() => MsgBox.Instance.Ask(labelMessage, defaultText, title, converter, verifier, ownerWindow));
 
 		public void Show(Exception exception, string? msg = null, Window? ownerWindow = null) =>

--- a/dnSpy/dnSpy.Contracts.Debugger/Dialogs/IDbgEnvironmentEditorService.cs
+++ b/dnSpy/dnSpy.Contracts.Debugger/Dialogs/IDbgEnvironmentEditorService.cs
@@ -1,0 +1,32 @@
+/*
+    Copyright (C) 2024 ElektroKill
+
+    This file is part of dnSpy
+
+    dnSpy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    dnSpy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace dnSpy.Contracts.Debugger.Dialogs {
+	/// <summary>
+	/// Service used to display an edit dialog for a <see cref="DbgEnvironment"/>
+	/// </summary>
+	public interface IDbgEnvironmentEditorService {
+		/// <summary>
+		/// Display an edit dialog for the given set of environment variables.
+		/// </summary>
+		/// <param name="environment">The environment to edit</param>
+		/// <returns>true if the environment was modified, false otherwise</returns>
+		public bool ShowEditDialog(DbgEnvironment environment);
+	}
+}

--- a/dnSpy/dnSpy.Contracts.DnSpy/App/IMessageBoxService.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/App/IMessageBoxService.cs
@@ -60,7 +60,7 @@ namespace dnSpy.Contracts.App {
 		/// it's a valid value, else an error message to show to the user.</param>
 		/// <param name="ownerWindow">Owner window or null to use the main window</param>
 		/// <returns></returns>
-		T Ask<T>(string labelMessage, string? defaultText = null, string? title = null, Func<string, T>? converter = null, Func<string, string?>? verifier = null, Window? ownerWindow = null);
+		T? Ask<T>(string labelMessage, string? defaultText = null, string? title = null, Func<string, T>? converter = null, Func<string, string?>? verifier = null, Window? ownerWindow = null);
 
 		/// <summary>
 		/// Shows an exception message

--- a/dnSpy/dnSpy.Contracts.DnSpy/Scripting/Roslyn/IScriptGlobals.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Scripting/Roslyn/IScriptGlobals.cs
@@ -339,7 +339,7 @@ namespace dnSpy.Contracts.Scripting.Roslyn {
 		/// it's a valid value, else an error message to show to the user.</param>
 		/// <param name="ownerWindow">Owner window or null to use the main window</param>
 		/// <returns></returns>
-		T Ask<T>(string labelMessage, string? defaultText = null, string? title = null, Func<string, T>? converter = null, Func<string, string>? verifier = null, Window? ownerWindow = null);
+		T? Ask<T>(string labelMessage, string? defaultText = null, string? title = null, Func<string, T>? converter = null, Func<string, string>? verifier = null, Window? ownerWindow = null);
 
 		/// <summary>
 		/// Shows an exception message

--- a/dnSpy/dnSpy.Contracts.DnSpy/Text/ContentTypes.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Text/ContentTypes.cs
@@ -322,5 +322,15 @@ namespace dnSpy.Contracts.Text {
 		/// Default hex tooltip content type
 		/// </summary>
 		public const string DefaultHexToolTip = nameof(DefaultHexToolTip);
+
+		/// <summary>
+		/// Environment variable key
+		/// </summary>
+		public const string EnvironmentVariableKey = nameof(EnvironmentVariableKey);
+
+		/// <summary>
+		/// Environment variable value
+		/// </summary>
+		public const string EnvironmentVariableValue = nameof(EnvironmentVariableValue);
 	}
 }

--- a/dnSpy/dnSpy/Documents/Tabs/Dialogs/OpenDocumentListVM.cs
+++ b/dnSpy/dnSpy/Documents/Tabs/Dialogs/OpenDocumentListVM.cs
@@ -101,14 +101,14 @@ namespace dnSpy.Documents.Tabs.Dialogs {
 		readonly DocumentListService documentListService;
 		readonly HashSet<DocumentListVM> removedDocumentLists;
 		readonly List<DocumentListVM> addedDocumentLists;
-		readonly Func<string, string> askUser;
+		readonly Func<string, string?> askUser;
 		readonly CancellationTokenSource cancellationTokenSource;
 		readonly CancellationToken cancellationToken;
 
 		public IClassificationFormatMap ClassificationFormatMap { get; }
 		public ITextElementProvider TextElementProvider { get; }
 
-		public OpenDocumentListVM(bool syntaxHighlight, IClassificationFormatMap classificationFormatMap, ITextElementProvider textElementProvider, DocumentListService documentListService, Func<string, string> askUser) {
+		public OpenDocumentListVM(bool syntaxHighlight, IClassificationFormatMap classificationFormatMap, ITextElementProvider textElementProvider, DocumentListService documentListService, Func<string, string?> askUser) {
 			SyntaxHighlight = syntaxHighlight;
 			ClassificationFormatMap = classificationFormatMap;
 			TextElementProvider = textElementProvider;
@@ -188,7 +188,7 @@ namespace dnSpy.Documents.Tabs.Dialogs {
 			if (!CanCreateList)
 				return;
 			var name = askUser(dnSpy_Resources.OpenList_AskForName);
-			if (string.IsNullOrEmpty(name))
+			if (string2.IsNullOrEmpty(name))
 				return;
 
 			var vm = new DocumentListVM(this, new DocumentList(name), false, true);

--- a/dnSpy/dnSpy/MainApp/MessageBoxService.cs
+++ b/dnSpy/dnSpy/MainApp/MessageBoxService.cs
@@ -132,7 +132,7 @@ namespace dnSpy.MainApp {
 			catch (ExternalException) { }
 		}
 
-		public T Ask<T>(string labelMessage, string? defaultText, string? title, Func<string, T>? converter, Func<string, string?>? verifier, Window? ownerWindow) {
+		public T? Ask<T>(string labelMessage, string? defaultText, string? title, Func<string, T>? converter, Func<string, string?>? verifier, Window? ownerWindow) {
 			var win = new AskDlg();
 			if (converter is null)
 				converter = CreateDefaultConverter<T>();
@@ -146,8 +146,8 @@ namespace dnSpy.MainApp {
 			if (!string.IsNullOrWhiteSpace(title))
 				win.Title = title;
 			if (win.ShowDialog() != true)
-				return default!;
-			return (T)vm.Value!;
+				return default;
+			return (T?)vm.Value;
 		}
 
 		Func<string, T> CreateDefaultConverter<T>() {


### PR DESCRIPTION
Link to issue(s) this pull request covers:
fixes https://github.com/dnSpyEx/dnSpy/issues/312

### Problem
dnSpy did not allow configuring the environment variables passed to the debugged process.

### Solution
An additional field in the start debugging options dialog has been added to display the environment variables passed into the debugged process and allow editing them.
![image](https://github.com/dnSpyEx/dnSpy/assets/37494960/4512c203-57be-4024-86c2-3158ca8c1582)
The user can double-click on any entry in either column to edit the value. The variables can be removed and additional rows can be added using corresponding buttons. The `Reset` button will reset the dialog to the state before any changes where applied using it. The `Add Many` button allows the user to bulk add environment variables using the following format:
`key=value;key1=value1` with `"` symbols being allowed in case the value or key must contain `=` or `;` characters.


