### PR TITLE
Updated corner radius

### DIFF
--- a/dnSpy/dnSpy.Contracts.DnSpy/Controls/MetroWindow.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Controls/MetroWindow.cs
@@ -653,8 +653,8 @@ namespace dnSpy.Contracts.Controls {
 		static MetroWindow() => DefaultStyleKeyProperty.OverrideMetadata(typeof(MetroWindow), new FrameworkPropertyMetadata(typeof(MetroWindow)));
 
 		// If these get updated, also update the templates if necessary
-		static readonly CornerRadius CornerRadius = new CornerRadius(0, 0, 0, 0);
-		static readonly Thickness GlassFrameThickness = new Thickness(0);
+		static readonly CornerRadius CornerRadius = new CornerRadius(12, 12, 12, 12);
+		static readonly Thickness GlassFrameThickness = new Thickness(1);
 		// NOTE: Keep these in sync: CaptionHeight + ResizeBorderThickness.Top = GridCaptionHeight
 		static readonly double CaptionHeight = 20;
 		static readonly Thickness ResizeBorderThickness = new Thickness(10, 10, 5, 5);


### PR DESCRIPTION
Link to issue(s) this pull request covers:

### Problem
Dnspy using visual studio like GUI. But the 2k22 has a corner radius but dnspy doesnt have that.

### Solution
With the pull request i added 12px corner radius to metro window.

![image](https://github.com/dnSpyEx/dnSpy/assets/14323838/237d62b1-7545-4f27-a06d-9f7161561d0b)
![image](https://github.com/dnSpyEx/dnSpy/assets/14323838/0bc38a0b-e124-4604-a471-edf91e5c7cc1)
![image](https://github.com/dnSpyEx/dnSpy/assets/14323838/ce43e2df-03eb-4b17-a9df-dcf2e11ba72f)

                 
![image](https://github.com/dnSpyEx/dnSpy/assets/14323838/f5332ea0-5abe-4bf5-a33e-5e9226961c01)
![image](https://github.com/dnSpyEx/dnSpy/assets/14323838/04de4b52-51ad-4046-ae7d-14b7bc157eb5)
