### PR TITLE
Fix for URLs in .url files not being properly resolved to local paths.

### DIFF
--- a/dnSpy/dnSpy/Documents/TreeView/DocumentTreeView.cs
+++ b/dnSpy/dnSpy/Documents/TreeView/DocumentTreeView.cs
@@ -856,7 +856,7 @@ namespace dnSpy.Documents.TreeView {
 							break;
 						if (!urlUri.IsFile)
 							break;
-						filename = urlUri.AbsolutePath;
+						filename = urlUri.LocalPath;
 					}
 					else
 						break;


### PR DESCRIPTION
### Problem

Fixes modules not being detected as loaded since path separator did not match "/" vs "\\".

![image](https://github.com/user-attachments/assets/87b01186-7dc7-4fb2-87c7-c7e1a9902501)

### Solution

Apparently using LocalPath instead of AbsolutePath is the way to go here.
