### PR TITLE
feat: implement 'method implements interface' analyzer

### DIFF
--- a/Extensions/dnSpy.Analyzer/Properties/dnSpy.Analyzer.Resources.Designer.cs
+++ b/Extensions/dnSpy.Analyzer/Properties/dnSpy.Analyzer.Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace dnSpy.Analyzer.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class dnSpy_Analyzer_Resources {
@@ -183,6 +183,15 @@ namespace dnSpy.Analyzer.Properties {
         public static string ImplementedByTreeNode {
             get {
                 return ResourceManager.GetString("ImplementedByTreeNode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Implements.
+        /// </summary>
+        public static string ImplementsTreeNode {
+            get {
+                return ResourceManager.GetString("ImplementsTreeNode", resourceCulture);
             }
         }
         

--- a/Extensions/dnSpy.Analyzer/Properties/dnSpy.Analyzer.Resources.resx
+++ b/Extensions/dnSpy.Analyzer/Properties/dnSpy.Analyzer.Resources.resx
@@ -162,6 +162,9 @@
   <data name="SubtypesTreeNode" xml:space="preserve">
     <value>Subtypes</value>
   </data>
+  <data name="ImplementsTreeNode" xml:space="preserve">
+    <value>Implements</value>
+  </data>
   <data name="InstantiatedByTreeNode" xml:space="preserve">
     <value>Instantiated By</value>
   </data>

--- a/Extensions/dnSpy.Analyzer/TreeNodes/MethodImplementsInterfaceNode.cs
+++ b/Extensions/dnSpy.Analyzer/TreeNodes/MethodImplementsInterfaceNode.cs
@@ -1,0 +1,92 @@
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using dnlib.DotNet;
+using dnSpy.Analyzer.Properties;
+using dnSpy.Contracts.Decompiler;
+using dnSpy.Contracts.Text;
+
+namespace dnSpy.Analyzer.TreeNodes {
+	sealed class MethodImplementsInterfaceNode : SearchNode {
+		readonly MethodDef analyzedMethod;
+
+		public MethodImplementsInterfaceNode(MethodDef analyzedMethod) => this.analyzedMethod = analyzedMethod ?? throw new ArgumentNullException(nameof(analyzedMethod));
+
+		protected override void Write(ITextColorWriter output, IDecompiler decompiler) =>
+			output.Write(BoxedTextColor.Text, dnSpy_Analyzer_Resources.ImplementsTreeNode);
+
+		protected override IEnumerable<AnalyzerTreeNodeData> FetchChildren(CancellationToken ct) {
+			bool includeAllModules = true;
+			// explicitly implemented interface methods are private -> ForcePublic required
+			var options = analyzedMethod.HasOverrides ? ScopedWhereUsedAnalyzerOptions.ForcePublic : ScopedWhereUsedAnalyzerOptions.None;
+			if (includeAllModules)
+				options |= ScopedWhereUsedAnalyzerOptions.IncludeAllModules;
+			var analyzer = new ScopedWhereUsedAnalyzer<AnalyzerTreeNodeData>(Context.DocumentService, analyzedMethod, FindReferencesInType, options);
+			return analyzer.PerformAnalysis(ct);
+		}
+
+		// logic for COM interfaces not implemented yet
+		IEnumerable<AnalyzerTreeNodeData> FindReferencesInType(TypeDef type) {
+			if (!type.IsInterface)
+				yield break;
+
+			if (analyzedMethod is { IsVirtual: false, IsStatic: false } || analyzedMethod.IsAbstract) {
+				yield break;
+			}
+
+			// explicit interface implementation
+			if (analyzedMethod.HasOverrides) {
+				foreach (var interfaceMethod in type.Methods) {
+					if (!analyzedMethod.Overrides.Any(x => CheckOverride(x, interfaceMethod))) continue;
+					yield return new MethodNode(interfaceMethod) { Context = Context };
+					yield break;
+				}
+			}
+
+			// implicit interface implementation
+			var implementedInterfaceRef = InterfaceMethodImplementedByNode.GetInterface(analyzedMethod.DeclaringType, type);
+			if (implementedInterfaceRef is not null) {
+				foreach (var method in type.Methods) {
+					if (method.Name != analyzedMethod.Name)
+						continue;
+					// implicit implementation only works for static methods if they are declared abstract in the interface
+					if ((!method.IsStatic || method.IsAbstract)
+					    && TypesHierarchyHelpers.MatchInterfaceMethod(method, analyzedMethod, implementedInterfaceRef)
+					) {
+						yield return new MethodNode(method) { Context = Context };
+						yield break;
+					}
+				}
+			}
+		}
+
+		bool CheckOverride(MethodOverride m, MethodDef interfaceMethod) {
+			if (m.MethodDeclaration.ResolveMethodDef() is not { } method)
+				return false;
+			return CheckEquals(method, interfaceMethod);
+		}
+
+		// Methods defined by an interface are not excluded in general, because they can provide a default implementation for another interface.
+		// Interface methods without an implementation are excluded through the abstract check.
+		// Methods on interfaces can only implement methods of other interfaces via explicit interface implementation (checked via HasOverrides).
+		public static bool CanShow(MethodDef method) => !method.IsAbstract
+		                                                && (method.IsVirtual || method.IsStatic) && (!method.DeclaringType.IsInterface || method.HasOverrides);
+	}
+}

--- a/Extensions/dnSpy.Analyzer/TreeNodes/MethodNode.cs
+++ b/Extensions/dnSpy.Analyzer/TreeNodes/MethodNode.cs
@@ -70,6 +70,9 @@ namespace dnSpy.Analyzer.TreeNodes {
 
 			if (InterfaceMethodImplementedByNode.CanShow(analyzedMethod))
 				yield return new InterfaceMethodImplementedByNode(analyzedMethod);
+
+			if (MethodImplementsInterfaceNode.CanShow(analyzedMethod))
+				yield return new MethodImplementsInterfaceNode(analyzedMethod);
 		}
 
 		public override IMemberRef? Member => analyzedMethod;


### PR DESCRIPTION
Link to issue(s) this pull request covers:
\-

### Problem
I want to find all the interface methods that are implemented by the analyzed method. This makes navigating unknown assemblies easier if they are predominantly programmed against interfaces instead of classes.

### Solution
The 'method implements interface' analyzer shows all interface methods that are implemented by the analyzed method.

The implementation is analogous to the 'interface method implemented by' analyzer (InterfaceMethodImplementedByNode.cs), that implements the reverse analysis direction of the analyzer implemented here in this commit.

In the current state, COM interfaces are not considered in this analyzer.
