### PR TITLE
Update default options of builtin hex editor to match external hex editor

### DIFF
--- a/dnSpy/dnSpy/Hex/Editor/HexGroups/HexEditorGroupFactoryServiceImpl.cs
+++ b/dnSpy/dnSpy/Hex/Editor/HexGroups/HexEditorGroupFactoryServiceImpl.cs
@@ -60,9 +60,9 @@ namespace dnSpy.Hex.Editor.HexGroups {
 			options.EndPosition = hexView.Buffer.Span.End;
 			options.BasePosition = HexPosition.Zero;
 			options.UseRelativePositions = false;
-			options.OffsetBitSize = 0;
+			options.OffsetBitSize = 32;
 			options.HexValuesDisplayFormat = HexValuesDisplayFormat.HexByte;
-			options.BytesPerLine = 0;
+			options.BytesPerLine = 16;
 			return options;
 		}
 	}


### PR DESCRIPTION
Change offset bit size to 32 and bytes per line to 16, so it will match the behaviour of common hex editor / viewer such as 010Editor and xxd, which makes it easier to do things like one byte CIL patch.