### PR TITLE
fix winform control complie

### DIFF
--- a/dnSpy/dnSpy.Decompiler/MSBuild/DotNetUtils.cs
+++ b/dnSpy/dnSpy.Decompiler/MSBuild/DotNetUtils.cs
@@ -35,7 +35,7 @@ namespace dnSpy.Decompiler.MSBuild {
 			return false;
 		}
 
-		public static bool IsWinForm(TypeDef type) => IsType(type, "System.Windows.Forms.Form");
+		public static bool IsWinForm(TypeDef type) => IsType(type, "System.Windows.Forms.Control") && type.Fields.Any(f => f.Name == "components" && f.FieldType.FullName == "System.ComponentModel.IContainer");
 		public static bool IsSystemWindowsApplication(TypeDef type) => IsType(type, "System.Windows.Application");
 		public static bool IsStartUpClass(TypeDef type) => type.Module.EntryPoint is not null && type.Module.EntryPoint.DeclaringType == type;
 		public static bool IsUnsafe(ModuleDef module) => module.CustomAttributes.IsDefined("System.Security.UnverifiableCodeAttribute");


### PR DESCRIPTION
Link to issue(s) this pull request covers:

### Problem
Custom control derived from 'System.Windows.Forms.Control' compilation error

### Solution
Modify the judgment condition of 'IsWInForm' to be derived from 'System. Windows. Forms. Control' and contain a field of type 'System. Component. IContainer' with the name 'components'
