### PR TITLE
Add optional decompiler hook for custom member display names in tree nodes

### DIFF
--- a/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/NodeFormatter.cs
+++ b/dnSpy/dnSpy.Contracts.DnSpy/Documents/TreeView/NodeFormatter.cs
@@ -33,6 +33,9 @@ namespace dnSpy.Contracts.Documents.TreeView {
 	public readonly struct NodeFormatter {
 		static bool IsExe(ModuleDef? mod) => mod is not null && (mod.Characteristics & Characteristics.Dll) == 0;
 		static bool IsExe(IPEImage? peImage) => peImage is not null && (peImage.ImageNTHeaders.FileHeader.Characteristics & Characteristics.Dll) == 0;
+		static string? GetDisplayName(IDecompiler decompiler, IMemberRef member) => (decompiler as IDecompilerMemberNameProvider)?.GetDisplayName(member);
+		static void WriteDisplayName(ITextColorWriter output, IDecompiler decompiler, IMemberRef member, object color, string metadataName) =>
+			output.Write(color, NameUtilities.CleanIdentifier(GetDisplayName(decompiler, member) ?? metadataName));
 
 		static string GetFilename(IDsDocument document) {
 			string? filename = null;
@@ -197,7 +200,7 @@ namespace dnSpy.Contracts.Documents.TreeView {
 		/// <param name="event">Event</param>
 		/// <param name="showToken">true to write tokens</param>
 		public void Write(ITextColorWriter output, IDecompiler decompiler, EventDef @event, bool showToken) {
-			output.Write(decompiler.MetadataTextColorProvider.GetColor(@event), NameUtilities.CleanIdentifier(@event.Name));
+			WriteDisplayName(output, decompiler, @event, decompiler.MetadataTextColorProvider.GetColor(@event), @event.Name);
 			output.WriteSpace();
 			output.Write(BoxedTextColor.Punctuation, ":");
 			output.WriteSpace();
@@ -239,7 +242,7 @@ namespace dnSpy.Contracts.Documents.TreeView {
 		/// <param name="field">Field</param>
 		/// <param name="showToken">true to write tokens</param>
 		public void WriteField(ITextColorWriter output, IDecompiler decompiler, IField field, bool showToken) {
-			output.Write(decompiler.MetadataTextColorProvider.GetColor(field), NameUtilities.CleanIdentifier(field.Name));
+			WriteDisplayName(output, decompiler, field, decompiler.MetadataTextColorProvider.GetColor(field), field.Name);
 			output.WriteSpace();
 			output.Write(BoxedTextColor.Punctuation, ":");
 			output.WriteSpace();
@@ -270,7 +273,7 @@ namespace dnSpy.Contracts.Documents.TreeView {
 			if (name == ".ctor")
 				output.Write(decompiler.MetadataTextColorProvider.GetColor(method.DeclaringType), NameUtilities.CleanIdentifier(method.DeclaringType.Name));
 			else
-				output.Write(decompiler.MetadataTextColorProvider.GetColor(method), NameUtilities.CleanIdentifier(name));
+				WriteDisplayName(output, decompiler, method, decompiler.MetadataTextColorProvider.GetColor(method), name);
 
 			if (showGenericParams) {
 				if (m is MethodSpec ms && ms.GenericInstMethodSig is GenericInstMethodSig gis) {

--- a/dnSpy/dnSpy.Contracts.Logic/Decompiler/IDecompilerMemberNameProvider.cs
+++ b/dnSpy/dnSpy.Contracts.Logic/Decompiler/IDecompilerMemberNameProvider.cs
@@ -1,0 +1,34 @@
+/*
+    Copyright (C) 2026 geocine
+
+    This file is part of dnSpy
+
+    dnSpy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    dnSpy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with dnSpy.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using dnlib.DotNet;
+
+namespace dnSpy.Contracts.Decompiler {
+	/// <summary>
+	/// Optional member display name provider used by UI formatters outside normal decompiler output.
+	/// </summary>
+	public interface IDecompilerMemberNameProvider {
+		/// <summary>
+		/// Returns a custom display name for <paramref name="member"/>, or <c>null</c> to use its metadata name.
+		/// </summary>
+		/// <param name="member">Member reference</param>
+		/// <returns></returns>
+		string? GetDisplayName(IMemberRef member);
+	}
+}


### PR DESCRIPTION
This is intended as a generic extensibility fix for custom decompilers, not a behavior change for built in dnSpy decompilers

## Problem
Today, dnSpy tree labels for some member kinds still use raw metadata names directly in `NodeFormatter` instead of asking the active decompiler for a display name.

That means custom decompilers or decompiler decorators can change names in decompiled output, but the document tree on the left can still show the original metadata names. The result is inconsistent UI between the tree and the decompiled text.

## Solution
This PR adds a new optional interface:

- `IDecompilerMemberNameProvider`

and updates `NodeFormatter` to use it for member kinds where the tree currently hardcodes metadata names:

- methods
- fields
- events

I wanted to keep the change generic and non invasive:

- no behavior change for existing decompilers
- no dependency on any specific extension or renaming system
- custom decompilers can opt in only if they need custom tree labels
- avoids pushing plugin specific logic into dnSpy core

## Impact

For built in dnSpy behavior, this should be a noop unless a decompiler explicitly implements the new interface.

For custom decompilers/decorators, this makes it possible to keep the document tree labels consistent with the names shown in decompiled output.

This is also useful for plugin development where decompiler behavior is extended outside upstream dnSpy. In my case, this helps sourcemap name remapping stay consistent between the decompiled text and the document tree without carrying a larger fork specific patch in dnSpy core.
