### PR TITLE
Preserve and display method body sequence points

### DIFF
--- a/Extensions/dnSpy.AsmEditor/MethodBody/CilBodyOptions.cs
+++ b/Extensions/dnSpy.AsmEditor/MethodBody/CilBodyOptions.cs
@@ -37,7 +37,7 @@ namespace dnSpy.AsmEditor.MethodBody {
 		public List<Instruction> Instructions = new List<Instruction>();
 		public List<ExceptionHandler> ExceptionHandlers = new List<ExceptionHandler>();
 		public List<Local> Locals = new List<Local>();
-		public PdbMethod? PdbMethod;//TODO: Use this
+		public PdbMethod? PdbMethod;
 
 		public CilBodyOptions() {
 		}

--- a/Extensions/dnSpy.AsmEditor/MethodBody/CilBodyVM.cs
+++ b/Extensions/dnSpy.AsmEditor/MethodBody/CilBodyVM.cs
@@ -59,7 +59,6 @@ namespace dnSpy.AsmEditor.MethodBody {
 			}
 		}
 		bool keepOldMaxStack;
-
 		public bool InitLocals {
 			get => initLocals;
 			set {
@@ -783,6 +782,7 @@ namespace dnSpy.AsmEditor.MethodBody {
 			options.MaxStack = MaxStack.Value;
 			options.LocalVarSigTok = LocalVarSigTok.Value;
 			options.HeaderSize = HeaderSize.Value;
+			options.PdbMethod = origOptions.PdbMethod;
 			options.Locals.Clear();
 			options.Locals.AddRange(LocalsListVM.Select(a => (Local)ops[a]));
 			options.Instructions.Clear();

--- a/Extensions/dnSpy.AsmEditor/MethodBody/InstructionOptions.cs
+++ b/Extensions/dnSpy.AsmEditor/MethodBody/InstructionOptions.cs
@@ -25,7 +25,7 @@ namespace dnSpy.AsmEditor.MethodBody {
 	sealed class InstructionOptions {
 		public Code Code;
 		public object? Operand;
-		public SequencePoint? SequencePoint;//TODO: Use this
+		public SequencePoint? SequencePoint;
 
 		public InstructionOptions() {
 		}

--- a/Extensions/dnSpy.AsmEditor/MethodBody/InstructionVM.cs
+++ b/Extensions/dnSpy.AsmEditor/MethodBody/InstructionVM.cs
@@ -19,12 +19,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Windows.Input;
 using dnlib.DotNet;
 using dnlib.DotNet.Emit;
 using dnlib.DotNet.Pdb;
 using dnSpy.AsmEditor.Commands;
+using dnSpy.AsmEditor.Properties;
 using dnSpy.Contracts.MVVM;
 
 namespace dnSpy.AsmEditor.MethodBody {
@@ -89,10 +91,43 @@ namespace dnSpy.AsmEditor.MethodBody {
 				if (sequencePoint != value) {
 					sequencePoint = value;
 					OnPropertyChanged(nameof(SequencePoint));
+					OnPropertyChanged(nameof(SequencePointDisplay));
+					OnPropertyChanged(nameof(SequencePointToolTip));
 				}
 			}
 		}
 		SequencePoint? sequencePoint;
+
+		public string SequencePointDisplay {
+			get => FormatSequencePoint(SequencePoint, fullPath: false);
+		}
+
+		public string SequencePointToolTip {
+			get => FormatSequencePoint(SequencePoint, fullPath: true);
+		}
+
+		const int HiddenSequencePointLine = 0xFEEFEE;
+
+		static string FormatSequencePoint(SequencePoint? sp, bool fullPath) {
+			if (sp is null)
+				return string.Empty;
+			if (sp.StartLine == HiddenSequencePointLine || sp.EndLine == HiddenSequencePointLine)
+				return dnSpy_AsmEditor_Resources.StatusHidden;
+
+			var documentUrl = sp.Document?.Url;
+			var source = string.Empty;
+			if (!string.IsNullOrEmpty(documentUrl))
+				source = fullPath ? documentUrl : Path.GetFileName(documentUrl);
+			if (!string.IsNullOrEmpty(source))
+				source += ":";
+
+			if (sp.StartLine == sp.EndLine && sp.StartColumn == sp.EndColumn)
+				return source + sp.StartLine.ToString() + "," + sp.StartColumn.ToString();
+			return source +
+				sp.StartLine.ToString() + "," + sp.StartColumn.ToString() +
+				"-" +
+				sp.EndLine.ToString() + "," + sp.EndColumn.ToString();
+		}
 
 		InstructionVM(bool dummy) {
 			InstructionOperandVM = null!;
@@ -234,6 +269,7 @@ namespace dnSpy.AsmEditor.MethodBody {
 			var instr = new InstructionVM();
 			instr.Code = Code;
 			instr.InstructionOperandVM.ImportFrom(ownerModule, InstructionOperandVM);
+			instr.SequencePoint = SequencePoint;
 			instr.Offset = offset;
 			return instr;
 		}

--- a/Extensions/dnSpy.AsmEditor/MethodBody/MethodBodyControl.xaml
+++ b/Extensions/dnSpy.AsmEditor/MethodBody/MethodBodyControl.xaml
@@ -134,6 +134,13 @@
                                         </DataTemplate>
                                     </GridViewColumn.CellTemplate>
                                 </GridViewColumn>
+                                <GridViewColumn Header="{x:Static p:dnSpy_AsmEditor_Resources.MethodBody_Column_SequencePoint}" Width="150">
+                                    <GridViewColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Style="{StaticResource CilLabelTextBlockStyle}" Text="{Binding SequencePointDisplay}" ToolTip="{Binding SequencePointToolTip}" />
+                                        </DataTemplate>
+                                    </GridViewColumn.CellTemplate>
+                                </GridViewColumn>
                                 <GridViewColumn Header="{x:Static p:dnSpy_AsmEditor_Resources.MethodBody_Column_OpCode}" Width="75">
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>

--- a/Extensions/dnSpy.AsmEditor/Properties/dnSpy.AsmEditor.Resources.Designer.cs
+++ b/Extensions/dnSpy.AsmEditor/Properties/dnSpy.AsmEditor.Resources.Designer.cs
@@ -3920,6 +3920,15 @@ namespace dnSpy.AsmEditor.Properties {
                 return ResourceManager.GetString("MethodBody_Column_OpCode", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sequence Point.
+        /// </summary>
+        public static string MethodBody_Column_SequencePoint {
+            get {
+                return ResourceManager.GetString("MethodBody_Column_SequencePoint", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Header O_ffset.

--- a/Extensions/dnSpy.AsmEditor/Properties/dnSpy.AsmEditor.Resources.it.resx
+++ b/Extensions/dnSpy.AsmEditor/Properties/dnSpy.AsmEditor.Resources.it.resx
@@ -2018,6 +2018,9 @@ Sei sicuro di volere uscire?</value>
   <data name="MethodBody_Column_OpCode" xml:space="preserve">
     <value>OpCode</value>
   </data>
+  <data name="MethodBody_Column_SequencePoint" xml:space="preserve">
+    <value>Punto sequenza</value>
+  </data>
   <data name="Column_Metadata_RID" xml:space="preserve">
     <value>RID</value>
   </data>

--- a/Extensions/dnSpy.AsmEditor/Properties/dnSpy.AsmEditor.Resources.resx
+++ b/Extensions/dnSpy.AsmEditor/Properties/dnSpy.AsmEditor.Resources.resx
@@ -2030,6 +2030,9 @@ Most options will be re-initialized when this checkbox is clicked</value>
   <data name="MethodBody_Column_OpCode" xml:space="preserve">
     <value>OpCode</value>
   </data>
+  <data name="MethodBody_Column_SequencePoint" xml:space="preserve">
+    <value>Sequence Point</value>
+  </data>
   <data name="Column_Metadata_RID" xml:space="preserve">
     <value>RID</value>
   </data>


### PR DESCRIPTION
Link to issue(s) this pull request covers:

### Problem
The CIL Method Body editor already loads PDB sequence point information, but this information was not visible in the instructions grid and could be lost during some edit/import flows.

This makes it harder to inspect how IL instructions map back to source lines when a matching PDB is available.

### Solution
Preserve method body PDB information when copying CIL body options and preserve instruction sequence points when importing instructions.

This also adds a read-only "Sequence Point" column to the Method Body editor. The column shows the source file plus line/column range, and the tooltip shows the full source path when available. Hidden sequence points are displayed using the existing localized resource.

Tested with:
- `dnSpy.AsmEditor` `net48` build
- `dnSpy.AsmEditor` `net10.0-windows` build
- Manual check using `Newtonsoft.Json.dll` with matching PDB