### PR TITLE
feat(console): Add Linux build for dnSpyEx.Console

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,8 @@ jobs:
             package-name: net-win64
             build-dir: net10.0-windows\win-x64\publish
           - platform: net-linux
-            package-name: net-linux-x64
-            build-dir: net10.0\linux-x64\publish
+            package-name: net-linux
+            build-dir: net10.0-linux\publish
 
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
             build-dir: net10.0-windows\win-x64\publish
           - platform: net-linux
             package-name: net-linux
-            build-dir: net10.0-linux\publish
+            build-dir: net10.0-linux
 
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           shell: pwsh
     strategy:
       matrix:
-        platform: [netframework, net, net-x86, net-x64]
+        platform: [netframework, net, net-x86, net-x64, net-linux]
         include:
           - platform: netframework
             package-name: netframework
@@ -34,6 +34,9 @@ jobs:
           - platform: net-x64
             package-name: net-win64
             build-dir: net10.0-windows\win-x64\publish
+          - platform: net-linux
+            package-name: net-linux-x64
+            build-dir: net10.0\linux-x64\publish
 
     steps:
       - uses: actions/checkout@v7.0.1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,2 +1,5 @@
 <Project>
+  <PropertyGroup Condition=" '$(MSBuildProjectName)' == 'dnSpy.Console' Or '$(MSBuildProjectName)' == 'dnSpy.Contracts.Logic' Or '$(MSBuildProjectName)' == 'dnSpy.Decompiler' Or '$(MSBuildProjectName)' == 'dnSpy.Decompiler.ILSpy.Core' Or '$(MSBuildProjectName)' == 'ICSharpCode.Decompiler' Or '$(MSBuildProjectName)' == 'ICSharpCode.NRefactory' Or '$(MSBuildProjectName)' == 'ICSharpCode.NRefactory.CSharp' Or '$(MSBuildProjectName)' == 'ICSharpCode.NRefactory.VB' ">
+    <SupportsCrossPlatform>true</SupportsCrossPlatform>
+  </PropertyGroup>
 </Project>

--- a/DnSpyCommon.props
+++ b/DnSpyCommon.props
@@ -7,6 +7,7 @@
         - DnSpyRoslyn.props
     NOTE: Update the ABOVE files when TargetFrameworks is updated -->
     <TargetFrameworks>net48;net10.0-windows</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(SupportsCrossPlatform)' == 'true' ">net48;net10.0-windows;net10.0</TargetFrameworks>
     <IsDotNetFramework>false</IsDotNetFramework>
     <IsDotNet>false</IsDotNet>
     <IsSelfContainedDotNet>false</IsSelfContainedDotNet>
@@ -22,6 +23,7 @@
     <CopyLocalLockFileAssemblies Condition=" '$(IsDotNet)' == 'true' ">true</CopyLocalLockFileAssemblies>
     <!-- If this gets updated, also update .github/workflows/build.yml and build.ps1 -->
     <DnSpyRuntimeIdentifiers>win-x86;win-x64</DnSpyRuntimeIdentifiers>
+    <DnSpyRuntimeIdentifiers Condition=" '$(SupportsCrossPlatform)' == 'true' ">win-x86;win-x64;linux-x64</DnSpyRuntimeIdentifiers>
     <SatelliteResourceLanguages>cs;de;es;es-ES;fa;fr;hu;it;pt-BR;pt-PT;ru;tr;uk;zh-CN;vi</SatelliteResourceLanguages>
 
     <!-- Allow compiling for windows on non-windows platforms -->

--- a/DnSpyCommon.props
+++ b/DnSpyCommon.props
@@ -23,7 +23,7 @@
     <CopyLocalLockFileAssemblies Condition=" '$(IsDotNet)' == 'true' ">true</CopyLocalLockFileAssemblies>
     <!-- If this gets updated, also update .github/workflows/build.yml and build.ps1 -->
     <DnSpyRuntimeIdentifiers>win-x86;win-x64</DnSpyRuntimeIdentifiers>
-    <DnSpyRuntimeIdentifiers Condition=" '$(SupportsCrossPlatform)' == 'true' ">win-x86;win-x64;linux-x64</DnSpyRuntimeIdentifiers>
+    <DnSpyRuntimeIdentifiers Condition=" '$(TargetFramework)' == 'net10.0' ">linux-x64</DnSpyRuntimeIdentifiers>
     <SatelliteResourceLanguages>cs;de;es;es-ES;fa;fr;hu;it;pt-BR;pt-PT;ru;tr;uk;zh-CN;vi</SatelliteResourceLanguages>
 
     <!-- Allow compiling for windows on non-windows platforms -->

--- a/Extensions/ILSpy.Decompiler/dnSpy.Decompiler.ILSpy.Core/dnSpy.Decompiler.ILSpy.Core.csproj
+++ b/Extensions/ILSpy.Decompiler/dnSpy.Decompiler.ILSpy.Core/dnSpy.Decompiler.ILSpy.Core.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <SupportsCrossPlatform>true</SupportsCrossPlatform>
+  </PropertyGroup>
+
   <Import Project="..\..\..\DnSpyCommon.props" />
 
   <PropertyGroup>

--- a/build.ps1
+++ b/build.ps1
@@ -108,11 +108,11 @@ function Build-NetLinux {
 	$publishDir = "$outdir\publish"
 
 	if ($NoMsbuild) {
-		dotnet publish -v:m -c $configuration -f net10.0 -r $rid -p:SelfContained=false dnSpy\dnSpy.Console\dnSpy.Console.csproj
+		dotnet publish -v:m -c $configuration -f net10.0 -r $rid -p:SelfContained=false -p:PublishDir="$publishDir/" dnSpy\dnSpy.Console\dnSpy.Console.csproj
 		if ($LASTEXITCODE) { exit $LASTEXITCODE }
 	}
 	else {
-		msbuild -v:m -m -restore -t:Publish -p:Configuration=$configuration -p:TargetFramework=net10.0 -p:RuntimeIdentifier=$rid -p:SelfContained=false dnSpy\dnSpy.Console\dnSpy.Console.csproj
+		msbuild -v:m -m -restore -t:Publish -p:Configuration=$configuration -p:TargetFramework=net10.0 -p:RuntimeIdentifier=$rid -p:SelfContained=false -p:PublishDir="$publishDir/" dnSpy\dnSpy.Console\dnSpy.Console.csproj
 		if ($LASTEXITCODE) { exit $LASTEXITCODE }
 	}
 

--- a/build.ps1
+++ b/build.ps1
@@ -104,28 +104,21 @@ function Build-NetLinux {
 	Write-Host "Building .NET Linux x64 binaries"
 
 	$rid = "linux-x64"
-	$outdir = "$net_baseoutput\net10.0-linux"
-	$publishDir = "$outdir\publish"
-	$absolutePublishDir = $publishDir
-	if ($PSScriptRoot) {
-		$absolutePublishDir = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot $publishDir))
-	} else {
-		$absolutePublishDir = [System.IO.Path]::GetFullPath($publishDir)
-	}
+	$publishDir = "$PSScriptRoot\$net_baseoutput\net10.0-linux\publish"
 
 	if ($NoMsbuild) {
-		dotnet publish -v:m -c $configuration -f net10.0 -r $rid -p:SelfContained=false -p:PublishDir="$absolutePublishDir/" dnSpy\dnSpy.Console\dnSpy.Console.csproj
+		dotnet publish -v:m -c $configuration -f net10.0 -r $rid -p:SelfContained=false -p:PublishDir="$publishDir/" dnSpy\dnSpy.Console\dnSpy.Console.csproj
 		if ($LASTEXITCODE) { exit $LASTEXITCODE }
 	}
 	else {
-		msbuild -v:m -m -restore -t:Publish -p:Configuration=$configuration -p:TargetFramework=net10.0 -p:RuntimeIdentifier=$rid -p:SelfContained=false -p:PublishDir="$absolutePublishDir/" dnSpy\dnSpy.Console\dnSpy.Console.csproj
+		msbuild -v:m -m -restore -t:Publish -p:Configuration=$configuration -p:TargetFramework=net10.0 -p:RuntimeIdentifier=$rid -p:SelfContained=false -p:PublishDir="$publishDir/" dnSpy\dnSpy.Console\dnSpy.Console.csproj
 		if ($LASTEXITCODE) { exit $LASTEXITCODE }
 	}
 
 	dotnet build -v:m -c $configuration -f net10.0 Extensions\ILSpy.Decompiler\dnSpy.Decompiler.ILSpy.Core\dnSpy.Decompiler.ILSpy.Core.csproj
 	if ($LASTEXITCODE) { exit $LASTEXITCODE }
 
-	Copy-Item -Path Extensions\ILSpy.Decompiler\dnSpy.Decompiler.ILSpy.Core\bin\$configuration\net10.0\*.dll -Destination $absolutePublishDir -Force
+	Copy-Item -Path Extensions\ILSpy.Decompiler\dnSpy.Decompiler.ILSpy.Core\bin\$configuration\net10.0\*.dll -Destination $publishDir -Force
 }
 
 $buildNetFramework  = $buildtfm -eq 'all' -or $buildtfm -eq 'netframework'

--- a/build.ps1
+++ b/build.ps1
@@ -106,20 +106,26 @@ function Build-NetLinux {
 	$rid = "linux-x64"
 	$outdir = "$net_baseoutput\net10.0-linux"
 	$publishDir = "$outdir\publish"
+	$absolutePublishDir = $publishDir
+	if ($PSScriptRoot) {
+		$absolutePublishDir = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot $publishDir))
+	} else {
+		$absolutePublishDir = [System.IO.Path]::GetFullPath($publishDir)
+	}
 
 	if ($NoMsbuild) {
-		dotnet publish -v:m -c $configuration -f net10.0 -r $rid -p:SelfContained=false dnSpy\dnSpy.Console\dnSpy.Console.csproj
+		dotnet publish -v:m -c $configuration -f net10.0 -r $rid -p:SelfContained=false -p:PublishDir="$absolutePublishDir/" dnSpy\dnSpy.Console\dnSpy.Console.csproj
 		if ($LASTEXITCODE) { exit $LASTEXITCODE }
 	}
 	else {
-		msbuild -v:m -m -restore -t:Publish -p:Configuration=$configuration -p:TargetFramework=net10.0 -p:RuntimeIdentifier=$rid -p:SelfContained=false dnSpy\dnSpy.Console\dnSpy.Console.csproj
+		msbuild -v:m -m -restore -t:Publish -p:Configuration=$configuration -p:TargetFramework=net10.0 -p:RuntimeIdentifier=$rid -p:SelfContained=false -p:PublishDir="$absolutePublishDir/" dnSpy\dnSpy.Console\dnSpy.Console.csproj
 		if ($LASTEXITCODE) { exit $LASTEXITCODE }
 	}
 
 	dotnet build -v:m -c $configuration -f net10.0 Extensions\ILSpy.Decompiler\dnSpy.Decompiler.ILSpy.Core\dnSpy.Decompiler.ILSpy.Core.csproj
 	if ($LASTEXITCODE) { exit $LASTEXITCODE }
 
-	Copy-Item -Path Extensions\ILSpy.Decompiler\dnSpy.Decompiler.ILSpy.Core\bin\$configuration\net10.0\*.dll -Destination $publishDir -Force
+	Copy-Item -Path Extensions\ILSpy.Decompiler\dnSpy.Decompiler.ILSpy.Core\bin\$configuration\net10.0\*.dll -Destination $absolutePublishDir -Force
 }
 
 $buildNetFramework  = $buildtfm -eq 'all' -or $buildtfm -eq 'netframework'

--- a/build.ps1
+++ b/build.ps1
@@ -104,7 +104,7 @@ function Build-NetLinux {
 	Write-Host "Building .NET Linux x64 binaries"
 
 	$rid = "linux-x64"
-	$outdir = "$net_baseoutput\net10.0\$rid"
+	$outdir = "$net_baseoutput\net10.0-linux"
 	$publishDir = "$outdir\publish"
 
 	if ($NoMsbuild) {

--- a/build.ps1
+++ b/build.ps1
@@ -104,7 +104,7 @@ function Build-NetLinux {
 	Write-Host "Building .NET Linux x64 binaries"
 
 	$rid = "linux-x64"
-	$publishDir = "$PSScriptRoot\$net_baseoutput\net10.0-linux\publish"
+	$publishDir = "$PSScriptRoot\$net_baseoutput\net10.0-linux"
 
 	if ($NoMsbuild) {
 		dotnet publish -v:m -c $configuration -f net10.0 -r $rid -p:SelfContained=false -p:PublishDir="$publishDir/" dnSpy\dnSpy.Console\dnSpy.Console.csproj

--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,5 @@
 param(
-	[ValidateSet("all","netframework","net","net-x86","net-x64")]
+	[ValidateSet("all","netframework","net","net-x86","net-x64","net-linux")]
 	[string]$buildtfm = 'all',
 	[switch]$NoMsbuild
 	)
@@ -100,10 +100,33 @@ function Build-SelfContainedNet {
 	}
 }
 
+function Build-NetLinux {
+	Write-Host "Building .NET Linux x64 binaries"
+
+	$rid = "linux-x64"
+	$outdir = "$net_baseoutput\net10.0\$rid"
+	$publishDir = "$outdir\publish"
+
+	if ($NoMsbuild) {
+		dotnet publish -v:m -c $configuration -f net10.0 -r $rid -p:SelfContained=false dnSpy\dnSpy.Console\dnSpy.Console.csproj
+		if ($LASTEXITCODE) { exit $LASTEXITCODE }
+	}
+	else {
+		msbuild -v:m -m -restore -t:Publish -p:Configuration=$configuration -p:TargetFramework=net10.0 -p:RuntimeIdentifier=$rid -p:SelfContained=false dnSpy\dnSpy.Console\dnSpy.Console.csproj
+		if ($LASTEXITCODE) { exit $LASTEXITCODE }
+	}
+
+	dotnet build -v:m -c $configuration -f net10.0 Extensions\ILSpy.Decompiler\dnSpy.Decompiler.ILSpy.Core\dnSpy.Decompiler.ILSpy.Core.csproj
+	if ($LASTEXITCODE) { exit $LASTEXITCODE }
+
+	Copy-Item -Path Extensions\ILSpy.Decompiler\dnSpy.Decompiler.ILSpy.Core\bin\$configuration\net10.0\*.dll -Destination $publishDir -Force
+}
+
 $buildNetFramework  = $buildtfm -eq 'all' -or $buildtfm -eq 'netframework'
 $buildNet           = $buildtfm -eq 'all' -or $buildtfm -eq 'net'
 $buildNetX86        = $buildtfm -eq 'all' -or $buildtfm -eq 'net-x86'
 $buildNetX64        = $buildtfm -eq 'all' -or $buildtfm -eq 'net-x64'
+$buildNetLinux      = $buildtfm -eq 'all' -or $buildtfm -eq 'net-linux'
 
 if ($buildNetX86 -or $buildNetX64 -or $buildNet) {
     Write-Host 'Building AppHostPatcher tool'
@@ -131,4 +154,8 @@ if ($buildNetX86) {
 
 if ($buildNetX64) {
 	Build-SelfContainedNet x64
+}
+
+if ($buildNetLinux) {
+	Build-NetLinux
 }

--- a/dnSpy/dnSpy.Console/dnSpy.Console.csproj
+++ b/dnSpy/dnSpy.Console/dnSpy.Console.csproj
@@ -1,10 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
 <!-- Target dir is the same as dnSpy.exe so we'll overwrite some files when creating
 a self-contained .NET app (System.Security.Permissions (wrong lower version), WindowsBase
 (wrong file (15KB, should be 1.1MB))).
 
-The workaround is to add WindowsDesktop above.
+The workaround is to use UseWPF/UseWindowsForms below.
 -->
+
+  <PropertyGroup>
+    <SupportsCrossPlatform>true</SupportsCrossPlatform>
+  </PropertyGroup>
 
   <Import Project="..\..\DnSpyCommon.props" />
 
@@ -22,9 +26,12 @@ The workaround is to add WindowsDesktop above.
     <OutputType>Exe</OutputType>
     <Prefer32Bit>false</Prefer32Bit>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <DisableWinExeOutputInference>true</DisableWinExeOutputInference>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net10.0' ">
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <DisableWinExeOutputInference>true</DisableWinExeOutputInference>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dnSpy/dnSpy.Contracts.Logic/Utilities/DotNetPathProvider.cs
+++ b/dnSpy/dnSpy.Contracts.Logic/Utilities/DotNetPathProvider.cs
@@ -327,12 +327,15 @@ namespace dnSpy.Contracts.Utilities {
 			}
 		}
 
+#pragma warning disable CA1416
+		// Disabling warning: this method is unreachable on Linux as it is only called in Windows OS if block of GetDotNetBaseDirCandidate
 		static bool TryGetInstallLocationFromRegistry(string regPath, [NotNullWhen(true)] out string? installLocation) {
 			using (var key = Registry.LocalMachine.OpenSubKey(regPath)) {
 				installLocation = key?.GetValue("InstallLocation") as string;
 				return installLocation is not null;
 			}
 		}
+#pragma warning restore CA1416
 
 		static IEnumerable<FrameworkPath> GetDotNetPathsShared(string basePath, int bitness) {
 			if (!Directory.Exists(basePath))

--- a/dnSpy/dnSpy.Contracts.Logic/dnSpy.Contracts.Logic.csproj
+++ b/dnSpy/dnSpy.Contracts.Logic/dnSpy.Contracts.Logic.csproj
@@ -17,6 +17,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Update="Properties\dnSpy.Contracts.Logic.Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/dnSpy/dnSpy.Contracts.Logic/dnSpy.Contracts.Logic.csproj
+++ b/dnSpy/dnSpy.Contracts.Logic/dnSpy.Contracts.Logic.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <SupportsCrossPlatform>true</SupportsCrossPlatform>
+  </PropertyGroup>
+
   <Import Project="..\..\DnSpyCommon.props" />
 
   <PropertyGroup>

--- a/dnSpy/dnSpy.Decompiler/MSBuild/ResXResourceFileWriter.cs
+++ b/dnSpy/dnSpy.Decompiler/MSBuild/ResXResourceFileWriter.cs
@@ -111,6 +111,87 @@ namespace dnSpy.Decompiler.MSBuild {
 
 			writer.WriteStartElement("root");
 
+#if NO_RESX_WRITER
+			const string ResourceSchema = @"
+  <xsd:schema xmlns="""" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:msdata=""urn:schemas-microsoft-com:xml-msdata"" id=""root"">
+    <xsd:import namespace=""http://www.w3.org/XML/1998/namespace""/>
+    <xsd:element name=""root"" msdata:IsDataSet=""true"">
+      <xsd:complexType>
+        <xsd:choice maxOccurs=""unbounded"">
+          <xsd:element name=""metadata"">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0""/>
+              </xsd:sequence>
+              <xsd:attribute name=""name"" use=""required"" type=""xsd:string""/>
+              <xsd:attribute name=""type"" type=""xsd:string""/>
+              <xsd:attribute name=""mimetype"" type=""xsd:string""/>
+              <xsd:attribute ref=""xml:space""/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name=""assembly"">
+            <xsd:complexType>
+              <xsd:attribute name=""alias"" type=""xsd:string""/>
+              <xsd:attribute name=""name"" type=""xsd:string""/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name=""data"">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""1""/>
+                <xsd:element name=""comment"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""2""/>
+              </xsd:sequence>
+              <xsd:attribute name=""name"" type=""xsd:string"" use=""required"" msdata:Ordinal=""1""/>
+              <xsd:attribute name=""type"" type=""xsd:string"" msdata:Ordinal=""3""/>
+              <xsd:attribute name=""mimetype"" type=""xsd:string"" msdata:Ordinal=""4""/>
+              <xsd:attribute ref=""xml:space""/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name=""resheader"">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""1""/>
+              </xsd:sequence>
+              <xsd:attribute name=""name"" type=""xsd:string"" use=""required""/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>";
+			var reader = new XmlTextReader(new StringReader(ResourceSchema)) {
+				WhitespaceHandling = WhitespaceHandling.None
+			};
+			writer.WriteNode(reader, true);
+
+			writer.WriteStartElement("resheader");
+			writer.WriteAttributeString("name", "resmimetype");
+			writer.WriteStartElement("value");
+			writer.WriteString("text/microsoft-resx");
+			writer.WriteEndElement();
+			writer.WriteEndElement();
+
+			writer.WriteStartElement("resheader");
+			writer.WriteAttributeString("name", "version");
+			writer.WriteStartElement("value");
+			writer.WriteString("2.0");
+			writer.WriteEndElement();
+			writer.WriteEndElement();
+
+			writer.WriteStartElement("resheader");
+			writer.WriteAttributeString("name", "reader");
+			writer.WriteStartElement("value");
+			writer.WriteString("System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+			writer.WriteEndElement();
+			writer.WriteEndElement();
+
+			writer.WriteStartElement("resheader");
+			writer.WriteAttributeString("name", "writer");
+			writer.WriteStartElement("value");
+			writer.WriteString("System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+			writer.WriteEndElement();
+			writer.WriteEndElement();
+#else
 			var reader = new XmlTextReader(new StringReader(ResXResourceWriter.ResourceSchema)) {
 				WhitespaceHandling = WhitespaceHandling.None
 			};
@@ -143,6 +224,7 @@ namespace dnSpy.Decompiler.MSBuild {
 			writer.WriteString(GetTypeName(typeof(ResXResourceWriter)));
 			writer.WriteEndElement();
 			writer.WriteEndElement();
+#endif
 		}
 
 		public void AddResourceData(ResourceElement resourceElement) {
@@ -227,7 +309,11 @@ namespace dnSpy.Decompiler.MSBuild {
 					bufWriter.Position = BufferOffset;
 					bufWriter.WriteBytes(data);
 					bufWriter.WriteByte(0x0B);
+#if NO_RESX_WRITER
+					return new ResXResourceInfo(ToBase64WrappedString(finalBuffer), null, "application/x-microsoft.net.object.binary.base64");
+#else
 					return new ResXResourceInfo(ToBase64WrappedString(finalBuffer), null, ResXResourceWriter.BinSerializedObjectMimeType);
+#endif
 				}
 				default:
 					throw new ArgumentOutOfRangeException();
@@ -236,12 +322,20 @@ namespace dnSpy.Decompiler.MSBuild {
 			if (resourceData is BinaryResourceData binaryResourceData) {
 				switch (binaryResourceData.Format) {
 				case SerializationFormat.BinaryFormatter:
+#if NO_RESX_WRITER
+					return new ResXResourceInfo(ToBase64WrappedString(binaryResourceData.Data), binaryResourceData.TypeName, "application/x-microsoft.net.object.binary.base64");
+#else
 					return new ResXResourceInfo(ToBase64WrappedString(binaryResourceData.Data), binaryResourceData.TypeName, ResXResourceWriter.BinSerializedObjectMimeType);
+#endif
 				case SerializationFormat.TypeConverterByteArray:
 				case SerializationFormat.ActivatorStream:
 					// RESX does not have a way to represent creation of an object using Activator.CreateInstance,
 					// so we fall back to the same representation as data passed into TypeConverter.
+#if NO_RESX_WRITER
+					return new ResXResourceInfo(ToBase64WrappedString(binaryResourceData.Data), binaryResourceData.TypeName, "application/x-microsoft.net.object.bytearray.base64");
+#else
 					return new ResXResourceInfo(ToBase64WrappedString(binaryResourceData.Data), binaryResourceData.TypeName, ResXResourceWriter.ByteArraySerializedObjectMimeType);
+#endif
 				case SerializationFormat.TypeConverterString:
 					return new ResXResourceInfo(Encoding.UTF8.GetString(binaryResourceData.Data), binaryResourceData.TypeName);
 				}
@@ -290,7 +384,11 @@ namespace dnSpy.Decompiler.MSBuild {
 				var asmRef = GetAssemblyRef("System.Windows.Forms");
 				if (asmRef is not null)
 					return new TypeRefUser(module, "System.Resources", "ResXNullRef", asmRef).AssemblyQualifiedName;
+#if NO_RESX_WRITER
+				return "System.Resources.ResXNullRef, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
+#else
 				return GetTypeName(typeof(ResXDataNode).Assembly.GetType("System.Resources.ResXNullRef")!);
+#endif
 			}
 			return typeCode switch {
 				ResourceTypeCode.String => module.CorLibTypes.String.AssemblyQualifiedName,

--- a/dnSpy/dnSpy.Decompiler/dnSpy.Decompiler.csproj
+++ b/dnSpy/dnSpy.Decompiler/dnSpy.Decompiler.csproj
@@ -1,4 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <SupportsCrossPlatform>true</SupportsCrossPlatform>
+  </PropertyGroup>
 
   <Import Project="..\..\DnSpyCommon.props" />
 
@@ -10,6 +14,13 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\dnSpy.snk</AssemblyOriginatorKeyFile>
     <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <DefineConstants>$(DefineConstants);NO_RESX_WRITER</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net10.0' ">
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
@@ -31,6 +42,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\dnSpy.Contracts.Logic\dnSpy.Contracts.Logic.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
+    <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/dnSpy/dnSpy.Decompiler/dnSpy.Decompiler.csproj
+++ b/dnSpy/dnSpy.Decompiler/dnSpy.Decompiler.csproj
@@ -46,8 +46,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
-    <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageReference Include="System.Resources.Extensions" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/dnSpy/dnSpy.Decompiler/dnSpy.Decompiler.csproj
+++ b/dnSpy/dnSpy.Decompiler/dnSpy.Decompiler.csproj
@@ -18,6 +18,7 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
     <DefineConstants>$(DefineConstants);NO_RESX_WRITER</DefineConstants>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' != 'net10.0' ">


### PR DESCRIPTION
Link to issue(s) this pull request covers:

### Problem
Currently, `dnSpyEx.Console` is only available for Windows. This restricts its availability on Linux-based systems, preventing automated tools, CI/CD pipelines, and modern Linux-hosted AI agents from easily running and interacting with dnSpyEx via CLI.

### Solution
- Added build/publish support for `dnSpyEx.Console` targeting Linux environments.
- Enables seamless CLI inspection and execution on Linux setups, facilitating easier integration with AI agents and command-line automation tools operating on Linux.


**Note:** This change focuses almost entirely on project config and doesn't introduce major modifications to existing codebase/logic.
  - Added clarifying comments for code that are unreachable on Linux.
  - Made minor adjustments to bypass Windows Forms `ResX` dependencies so the console can compile and run on Linux.