### PR TITLE
Remember last Start Debugging dialog options across restarts (#487)

### DIFF
--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Dialogs/DebugProgram/DotNetCommonStartDebuggingOptionsPage.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Dialogs/DebugProgram/DotNetCommonStartDebuggingOptionsPage.cs
@@ -26,6 +26,7 @@ using dnSpy.Contracts.Debugger.Dialogs;
 using dnSpy.Contracts.Debugger.DotNet.CorDebug;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
 using dnSpy.Contracts.MVVM;
+using dnSpy.Contracts.Settings;
 using dnSpy.Debugger.DotNet.CorDebug.Properties;
 
 namespace dnSpy.Debugger.DotNet.CorDebug.Dialogs.DebugProgram {
@@ -171,6 +172,25 @@ namespace dnSpy.Debugger.DotNet.CorDebug.Dialogs.DebugProgram {
 		protected T InitializeDefault<T>(T options, string breakKind) where T : CorDebugStartDebuggingOptions {
 			options.BreakKind = FilterBreakKind(breakKind);
 			return options;
+		}
+
+		protected static void SerializeCorDebugOptions(ISettingsSection section, CorDebugStartDebuggingOptions options) {
+			if (options.BreakKind is not null)
+				section.Attribute(nameof(options.BreakKind), options.BreakKind);
+			if (options.Filename is not null)
+				section.Attribute(nameof(options.Filename), options.Filename);
+			if (options.CommandLine is not null)
+				section.Attribute(nameof(options.CommandLine), options.CommandLine);
+			if (options.WorkingDirectory is not null)
+				section.Attribute(nameof(options.WorkingDirectory), options.WorkingDirectory);
+			// The environment isn't serialized, it always contains all of the current process' environment variables
+		}
+
+		protected static void DeserializeCorDebugOptions(ISettingsSection section, CorDebugStartDebuggingOptions options) {
+			options.BreakKind = section.Attribute<string>(nameof(options.BreakKind)) ?? options.BreakKind;
+			options.Filename = section.Attribute<string>(nameof(options.Filename));
+			options.CommandLine = section.Attribute<string>(nameof(options.CommandLine));
+			options.WorkingDirectory = section.Attribute<string>(nameof(options.WorkingDirectory));
 		}
 
 		protected T GetOptions<T>(T options) where T : CorDebugStartDebuggingOptions {

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Dialogs/DebugProgram/DotNetFrameworkStartDebuggingOptionsPage.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Dialogs/DebugProgram/DotNetFrameworkStartDebuggingOptionsPage.cs
@@ -29,6 +29,7 @@ using dnSpy.Contracts.Debugger.DotNet.CorDebug;
 using dnSpy.Contracts.Debugger.StartDebugging;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
 using dnSpy.Contracts.MVVM;
+using dnSpy.Contracts.Settings;
 using dnSpy.Debugger.DotNet.CorDebug.Properties;
 using dnSpy.Debugger.DotNet.CorDebug.Utilities;
 
@@ -119,6 +120,22 @@ namespace dnSpy.Debugger.DotNet.CorDebug.Dialogs.DebugProgram {
 
 			order = 0;
 			return false;
+		}
+
+		public override bool SerializeOptions(ISettingsSection section, StartDebuggingOptions options) {
+			if (options is not DotNetFrameworkStartDebuggingOptions dnfOptions)
+				return false;
+			SerializeCorDebugOptions(section, dnfOptions);
+			if (dnfOptions.DebuggeeVersion is not null)
+				section.Attribute(nameof(dnfOptions.DebuggeeVersion), dnfOptions.DebuggeeVersion);
+			return true;
+		}
+
+		public override StartDebuggingOptions? DeserializeOptions(ISettingsSection section) {
+			var options = new DotNetFrameworkStartDebuggingOptions();
+			DeserializeCorDebugOptions(section, options);
+			options.DebuggeeVersion = section.Attribute<string>(nameof(options.DebuggeeVersion));
+			return options;
 		}
 
 		protected override bool CalculateIsValid() => string.IsNullOrEmpty(Verify(nameof(Filename)));

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Dialogs/DebugProgram/DotNetStartDebuggingOptionsPage.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.CorDebug/Dialogs/DebugProgram/DotNetStartDebuggingOptionsPage.cs
@@ -28,6 +28,7 @@ using dnSpy.Contracts.Debugger.DotNet.CorDebug;
 using dnSpy.Contracts.Debugger.StartDebugging;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
 using dnSpy.Contracts.MVVM;
+using dnSpy.Contracts.Settings;
 using dnSpy.Debugger.DotNet.CorDebug.Utilities;
 
 namespace dnSpy.Debugger.DotNet.CorDebug.Dialogs.DebugProgram {
@@ -160,6 +161,29 @@ namespace dnSpy.Debugger.DotNet.CorDebug.Dialogs.DebugProgram {
 
 			order = 0;
 			return false;
+		}
+
+		public override bool SerializeOptions(ISettingsSection section, StartDebuggingOptions options) {
+			if (options is not DotNetStartDebuggingOptions dncOptions)
+				return false;
+			SerializeCorDebugOptions(section, dncOptions);
+			section.Attribute(nameof(dncOptions.UseHost), dncOptions.UseHost);
+			if (dncOptions.Host is not null)
+				section.Attribute(nameof(dncOptions.Host), dncOptions.Host);
+			if (dncOptions.HostArguments is not null)
+				section.Attribute(nameof(dncOptions.HostArguments), dncOptions.HostArguments);
+			section.Attribute(nameof(dncOptions.ConnectionTimeout), dncOptions.ConnectionTimeout);
+			return true;
+		}
+
+		public override StartDebuggingOptions? DeserializeOptions(ISettingsSection section) {
+			var options = new DotNetStartDebuggingOptions();
+			DeserializeCorDebugOptions(section, options);
+			options.UseHost = section.Attribute<bool?>(nameof(options.UseHost)) ?? options.UseHost;
+			options.Host = section.Attribute<string>(nameof(options.Host));
+			options.HostArguments = section.Attribute<string>(nameof(options.HostArguments));
+			options.ConnectionTimeout = section.Attribute<TimeSpan?>(nameof(options.ConnectionTimeout)) ?? options.ConnectionTimeout;
+			return options;
 		}
 
 		protected override bool CalculateIsValid() =>

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/MonoConnectStartDebuggingOptionsPage.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/MonoConnectStartDebuggingOptionsPage.cs
@@ -21,6 +21,7 @@ using System;
 using dnSpy.Contracts.Debugger;
 using dnSpy.Contracts.Debugger.DotNet.Mono;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
+using dnSpy.Contracts.Settings;
 using dnSpy.Debugger.DotNet.Mono.Properties;
 
 namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
@@ -55,6 +56,19 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 		public override StartDebuggingOptionsInfo GetOptions() {
 			var options = GetOptions(new MonoConnectStartDebuggingOptions());
 			return new StartDebuggingOptionsInfo(options, null, StartDebuggingOptionsInfoFlags.None);
+		}
+
+		public override bool SerializeOptions(ISettingsSection section, StartDebuggingOptions options) {
+			if (options is not MonoConnectStartDebuggingOptions connectOptions)
+				return false;
+			SerializeMonoConnectOptions(section, connectOptions);
+			return true;
+		}
+
+		public override StartDebuggingOptions? DeserializeOptions(ISettingsSection section) {
+			var options = new MonoConnectStartDebuggingOptions();
+			DeserializeMonoConnectOptions(section, options);
+			return options;
 		}
 	}
 }

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/MonoConnectStartDebuggingOptionsPageBase.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/MonoConnectStartDebuggingOptionsPageBase.cs
@@ -23,6 +23,7 @@ using dnSpy.Contracts.Debugger;
 using dnSpy.Contracts.Debugger.DotNet.Mono;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
 using dnSpy.Contracts.MVVM;
+using dnSpy.Contracts.Settings;
 
 namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 	abstract class MonoConnectStartDebuggingOptionsPageBase : StartDebuggingOptionsPage, IDataErrorInfo {
@@ -106,6 +107,24 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 			options.BreakKind = FilterBreakKind(BreakKind);
 			options.ProcessIsSuspended = ProcessIsSuspended;
 			return options;
+		}
+
+		protected static void SerializeMonoConnectOptions(ISettingsSection section, MonoConnectStartDebuggingOptionsBase options) {
+			if (options.BreakKind is not null)
+				section.Attribute(nameof(options.BreakKind), options.BreakKind);
+			if (options.Address is not null)
+				section.Attribute(nameof(options.Address), options.Address);
+			section.Attribute(nameof(options.Port), options.Port);
+			section.Attribute(nameof(options.ConnectionTimeout), options.ConnectionTimeout);
+			section.Attribute(nameof(options.ProcessIsSuspended), options.ProcessIsSuspended);
+		}
+
+		protected static void DeserializeMonoConnectOptions(ISettingsSection section, MonoConnectStartDebuggingOptionsBase options) {
+			options.BreakKind = section.Attribute<string>(nameof(options.BreakKind)) ?? options.BreakKind;
+			options.Address = section.Attribute<string>(nameof(options.Address));
+			options.Port = section.Attribute<ushort?>(nameof(options.Port)) ?? options.Port;
+			options.ConnectionTimeout = section.Attribute<TimeSpan?>(nameof(options.ConnectionTimeout)) ?? options.ConnectionTimeout;
+			options.ProcessIsSuspended = section.Attribute<bool?>(nameof(options.ProcessIsSuspended)) ?? options.ProcessIsSuspended;
 		}
 
 		string IDataErrorInfo.Error => throw new NotImplementedException();

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/MonoStartDebuggingOptionsPage.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/MonoStartDebuggingOptionsPage.cs
@@ -26,6 +26,7 @@ using dnSpy.Contracts.Debugger.DotNet.Mono;
 using dnSpy.Contracts.Debugger.StartDebugging;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
 using dnSpy.Contracts.MVVM;
+using dnSpy.Contracts.Settings;
 
 namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 	sealed class MonoStartDebuggingOptionsPage : MonoStartDebuggingOptionsPageBase {
@@ -124,6 +125,24 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 
 			order = 0;
 			return false;
+		}
+
+		public override bool SerializeOptions(ISettingsSection section, StartDebuggingOptions options) {
+			if (options is not MonoStartDebuggingOptions msdOptions)
+				return false;
+			SerializeMonoOptions(section, msdOptions);
+			if (msdOptions.MonoExePath is not null)
+				section.Attribute(nameof(msdOptions.MonoExePath), msdOptions.MonoExePath);
+			section.Attribute(nameof(msdOptions.MonoExeOptions), msdOptions.MonoExeOptions);
+			return true;
+		}
+
+		public override StartDebuggingOptions? DeserializeOptions(ISettingsSection section) {
+			var options = new MonoStartDebuggingOptions();
+			DeserializeMonoOptions(section, options);
+			options.MonoExePath = section.Attribute<string>(nameof(options.MonoExePath));
+			options.MonoExeOptions = section.Attribute<MonoExeOptions?>(nameof(options.MonoExeOptions)) ?? options.MonoExeOptions;
+			return options;
 		}
 
 		protected override bool CalculateIsValidCore() => string.IsNullOrEmpty(Verify(nameof(MonoExePath)));

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/MonoStartDebuggingOptionsPageBase.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/MonoStartDebuggingOptionsPageBase.cs
@@ -26,6 +26,7 @@ using dnSpy.Contracts.Debugger.Dialogs;
 using dnSpy.Contracts.Debugger.DotNet.Mono;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
 using dnSpy.Contracts.MVVM;
+using dnSpy.Contracts.Settings;
 using dnSpy.Debugger.DotNet.Mono.Properties;
 
 namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
@@ -192,6 +193,29 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 			options.ConnectionPort = ConnectionPort.Value;
 			options.ConnectionTimeout = TimeSpan.FromSeconds(ConnectionTimeout.Value);
 			options.BreakKind = FilterBreakKind(BreakKind);
+		}
+
+		protected static void SerializeMonoOptions(ISettingsSection section, MonoStartDebuggingOptionsBase options) {
+			if (options.BreakKind is not null)
+				section.Attribute(nameof(options.BreakKind), options.BreakKind);
+			if (options.Filename is not null)
+				section.Attribute(nameof(options.Filename), options.Filename);
+			if (options.CommandLine is not null)
+				section.Attribute(nameof(options.CommandLine), options.CommandLine);
+			if (options.WorkingDirectory is not null)
+				section.Attribute(nameof(options.WorkingDirectory), options.WorkingDirectory);
+			section.Attribute(nameof(options.ConnectionPort), options.ConnectionPort);
+			section.Attribute(nameof(options.ConnectionTimeout), options.ConnectionTimeout);
+			// The environment isn't serialized, it always contains all of the current process' environment variables
+		}
+
+		protected static void DeserializeMonoOptions(ISettingsSection section, MonoStartDebuggingOptionsBase options) {
+			options.BreakKind = section.Attribute<string>(nameof(options.BreakKind)) ?? options.BreakKind;
+			options.Filename = section.Attribute<string>(nameof(options.Filename));
+			options.CommandLine = section.Attribute<string>(nameof(options.CommandLine));
+			options.WorkingDirectory = section.Attribute<string>(nameof(options.WorkingDirectory));
+			options.ConnectionPort = section.Attribute<ushort?>(nameof(options.ConnectionPort)) ?? options.ConnectionPort;
+			options.ConnectionTimeout = section.Attribute<TimeSpan?>(nameof(options.ConnectionTimeout)) ?? options.ConnectionTimeout;
 		}
 
 		string IDataErrorInfo.Error => throw new NotImplementedException();

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/UnityConnectStartDebuggingOptionsPage.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/UnityConnectStartDebuggingOptionsPage.cs
@@ -23,6 +23,7 @@ using dnSpy.Contracts.Debugger;
 using dnSpy.Contracts.Debugger.DotNet.Mono;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
 using dnSpy.Contracts.MVVM;
+using dnSpy.Contracts.Settings;
 using dnSpy.Debugger.DotNet.Mono.Properties;
 
 namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
@@ -67,6 +68,19 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 		public override StartDebuggingOptionsInfo GetOptions() {
 			var options = GetOptions(new UnityConnectStartDebuggingOptions());
 			return new StartDebuggingOptionsInfo(options, null, StartDebuggingOptionsInfoFlags.None);
+		}
+
+		public override bool SerializeOptions(ISettingsSection section, StartDebuggingOptions options) {
+			if (options is not UnityConnectStartDebuggingOptions connectOptions)
+				return false;
+			SerializeMonoConnectOptions(section, connectOptions);
+			return true;
+		}
+
+		public override StartDebuggingOptions? DeserializeOptions(ISettingsSection section) {
+			var options = new UnityConnectStartDebuggingOptions { Port = DEFAULT_PORT };
+			DeserializeMonoConnectOptions(section, options);
+			return options;
 		}
 	}
 }

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/UnityStartDebuggingOptionsPage.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger.DotNet.Mono/Dialogs/DebugProgram/UnityStartDebuggingOptionsPage.cs
@@ -26,6 +26,7 @@ using dnSpy.Contracts.Debugger.DotNet.Mono;
 using dnSpy.Contracts.Debugger.StartDebugging;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
 using dnSpy.Contracts.MVVM;
+using dnSpy.Contracts.Settings;
 
 namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 	sealed class UnityStartDebuggingOptionsPage : MonoStartDebuggingOptionsPageBase {
@@ -102,6 +103,19 @@ namespace dnSpy.Debugger.DotNet.Mono.Dialogs.DebugProgram {
 
 			order = 0;
 			return false;
+		}
+
+		public override bool SerializeOptions(ISettingsSection section, StartDebuggingOptions options) {
+			if (options is not UnityStartDebuggingOptions usdOptions)
+				return false;
+			SerializeMonoOptions(section, usdOptions);
+			return true;
+		}
+
+		public override StartDebuggingOptions? DeserializeOptions(ISettingsSection section) {
+			var options = new UnityStartDebuggingOptions();
+			DeserializeMonoOptions(section, options);
+			return options;
 		}
 
 		protected override bool CalculateIsValidCore() => true;

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/DbgUI/StartDebuggingOptionsMru.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/DbgUI/StartDebuggingOptionsMru.cs
@@ -79,6 +79,12 @@ namespace dnSpy.Debugger.DbgUI {
 			return (info.Options, info.PageGuid);
 		}
 
+		public void SetLastOptions(StartDebuggingOptions options, Guid pageGuid) {
+			if (options is null)
+				throw new ArgumentNullException(nameof(options));
+			lastOptions = ((StartDebuggingOptions)options.Clone(), pageGuid);
+		}
+
 		public (StartDebuggingOptions options, Guid pageGuid)? TryGetLastOptions() => lastOptions;
 	}
 }

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/DbgUI/StartDebuggingOptionsProvider.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/DbgUI/StartDebuggingOptionsProvider.cs
@@ -32,23 +32,31 @@ using dnSpy.Contracts.Debugger.StartDebugging;
 using dnSpy.Contracts.Debugger.StartDebugging.Dialog;
 using dnSpy.Contracts.Documents.Tabs;
 using dnSpy.Contracts.Documents.TreeView;
+using dnSpy.Contracts.Settings;
 using dnSpy.Debugger.Dialogs.DebugProgram;
 using dnSpy.Debugger.Properties;
 
 namespace dnSpy.Debugger.DbgUI {
 	[Export(typeof(StartDebuggingOptionsProvider))]
 	sealed class StartDebuggingOptionsProvider {
+		static readonly Guid SETTINGS_GUID = new Guid("1D06F2C9-BC3C-4D44-93B3-729F939F3F97");
+		const string PageGuidAttr = "PageGuid";
+		const string OptionsSectionName = "Options";
+
 		readonly IAppWindow appWindow;
 		readonly IDocumentTabService documentTabService;
+		readonly ISettingsService settingsService;
 		readonly Lazy<StartDebuggingOptionsPageProvider>[] startDebuggingOptionsPageProviders;
 		readonly Lazy<DbgProcessStarterService> dbgProcessStarterService;
 		readonly Lazy<GenericDebugEngineGuidProvider, IGenericDebugEngineGuidProviderMetadata>[] genericDebugEngineGuidProviders;
 		readonly StartDebuggingOptionsMru mru;
+		bool mruLoaded;
 
 		[ImportingConstructor]
-		StartDebuggingOptionsProvider(IAppWindow appWindow, IDocumentTabService documentTabService, Lazy<DbgProcessStarterService> dbgProcessStarterService, [ImportMany] IEnumerable<Lazy<StartDebuggingOptionsPageProvider>> startDebuggingOptionsPageProviders, [ImportMany] IEnumerable<Lazy<GenericDebugEngineGuidProvider, IGenericDebugEngineGuidProviderMetadata>> genericDebugEngineGuidProviders) {
+		StartDebuggingOptionsProvider(IAppWindow appWindow, IDocumentTabService documentTabService, ISettingsService settingsService, Lazy<DbgProcessStarterService> dbgProcessStarterService, [ImportMany] IEnumerable<Lazy<StartDebuggingOptionsPageProvider>> startDebuggingOptionsPageProviders, [ImportMany] IEnumerable<Lazy<GenericDebugEngineGuidProvider, IGenericDebugEngineGuidProviderMetadata>> genericDebugEngineGuidProviders) {
 			this.appWindow = appWindow;
 			this.documentTabService = documentTabService;
+			this.settingsService = settingsService;
 			this.dbgProcessStarterService = dbgProcessStarterService;
 			this.startDebuggingOptionsPageProviders = startDebuggingOptionsPageProviders.ToArray();
 			this.genericDebugEngineGuidProviders = genericDebugEngineGuidProviders.OrderBy(a => a.Metadata.Order).ToArray();
@@ -84,6 +92,11 @@ namespace dnSpy.Debugger.DbgUI {
 			Debug.Assert(pages.Length != 0, "No debug engines!");
 			if (pages.Length == 0)
 				return default;
+
+			if (!mruLoaded) {
+				mruLoaded = true;
+				LoadLastOptions(pages);
+			}
 
 			var oldOptions = mru.TryGetOptions(filename);
 			var lastOptions = mru.TryGetLastOptions();
@@ -130,7 +143,34 @@ namespace dnSpy.Debugger.DbgUI {
 			}
 
 			mru.Add(info.Filename!, info.Options, vm.SelectedPageGuid);
+			SaveLastOptions(pages, info.Options, vm.SelectedPageGuid);
 			return (info.Options, info.Flags);
+		}
+
+		void LoadLastOptions(StartDebuggingOptionsPage[] pages) {
+			var section = settingsService.GetOrCreateSection(SETTINGS_GUID);
+			var pageGuid = section.Attribute<Guid?>(PageGuidAttr);
+			if (pageGuid is null)
+				return;
+			var optionsSection = section.TryGetSection(OptionsSectionName);
+			if (optionsSection is null)
+				return;
+			// The page could be missing, eg. if its extension got uninstalled or disabled
+			var page = pages.FirstOrDefault(a => a.Guid == pageGuid.Value);
+			var options = page?.DeserializeOptions(optionsSection);
+			if (options is null)
+				return;
+			mru.SetLastOptions(options, pageGuid.Value);
+		}
+
+		void SaveLastOptions(StartDebuggingOptionsPage[] pages, StartDebuggingOptions options, Guid pageGuid) {
+			var page = pages.FirstOrDefault(a => a.Guid == pageGuid);
+			if (page is null)
+				return;
+			var section = settingsService.RecreateSection(SETTINGS_GUID);
+			section.Attribute(PageGuidAttr, pageGuid);
+			if (!page.SerializeOptions(section.CreateSection(OptionsSectionName), options))
+				settingsService.RemoveSection(SETTINGS_GUID);
 		}
 
 		static bool? IsCompatibleWithCurrentArchitecture(string fileName) {

--- a/dnSpy/dnSpy.Contracts.Debugger/StartDebugging/Dialog/StartDebuggingOptionsPage.cs
+++ b/dnSpy/dnSpy.Contracts.Debugger/StartDebugging/Dialog/StartDebuggingOptionsPage.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.ComponentModel;
+using dnSpy.Contracts.Settings;
 
 namespace dnSpy.Contracts.Debugger.StartDebugging.Dialog {
 	/// <summary>
@@ -100,6 +101,24 @@ namespace dnSpy.Contracts.Debugger.StartDebugging.Dialog {
 		/// Called when the dialog box gets closed
 		/// </summary>
 		public virtual void OnClose() { }
+
+		/// <summary>
+		/// Serializes <paramref name="options"/> to <paramref name="section"/> so they can be
+		/// restored after dnSpy is restarted. Returns false if the options couldn't be serialized,
+		/// eg. it's an unsupported options type. The default implementation returns false.
+		/// </summary>
+		/// <param name="section">Destination section</param>
+		/// <param name="options">Options created by this page, see <see cref="GetOptions"/></param>
+		/// <returns></returns>
+		public virtual bool SerializeOptions(ISettingsSection section, StartDebuggingOptions options) => false;
+
+		/// <summary>
+		/// Deserializes options that were serialized by <see cref="SerializeOptions(ISettingsSection, StartDebuggingOptions)"/>
+		/// or returns null if they couldn't be deserialized. The default implementation returns null.
+		/// </summary>
+		/// <param name="section">Section</param>
+		/// <returns></returns>
+		public virtual StartDebuggingOptions? DeserializeOptions(ISettingsSection section) => null;
 	}
 
 	/// <summary>


### PR DESCRIPTION
Fixes #487

The Debug Program dialog setting where only in memory, so the executable, arguments, working directory etc. were lost on restart. This was quite annoying for me in the past. This PR persists the last-used options to the settings file and restores them the next time the dialog is opened.

The serialize helpers are intentionally implemented per engine (CorDebug / Mono / Mono-connect) even though they look similar: the options hierarchies only share BreakKind, and the engine contract assemblies don't reference each other. A shared helper would have required new cross-engine public API, so I followed the existing structure of the page base classes instead. Happy to change that if you want.

Tested under Windows with net48.